### PR TITLE
hotfix: enable Enter key to select first autocomplete result

### DIFF
--- a/app.js
+++ b/app.js
@@ -539,7 +539,8 @@ function App() {
         e.preventDefault();
         if (highlightedIndex >= 0) {
           handleTokenSelect(autocompleteTokens[highlightedIndex]);
-        } else if (autocompleteTokens.length === 1) {
+        } else if (autocompleteTokens.length > 0) {
+          // Select the first token if none is highlighted but results are available
           handleTokenSelect(autocompleteTokens[0]);
         }
         break;


### PR DESCRIPTION
- Modified Enter key handling to select first token when no item is highlighted
- Improves UX by allowing users to quickly select top search result
- Changed condition from exact match (length === 1) to any results (length > 0)