### PR TITLE
fix: move footer to React app to eliminate FOUC and layout shifts

### DIFF
--- a/app.js
+++ b/app.js
@@ -1198,6 +1198,18 @@ function App() {
           )
         )
       )
+    ),
+    // Footer
+    React.createElement('footer', { className: 'app-footer' },
+      React.createElement('p', null,
+        'Powered by ',
+        React.createElement('a', {
+          href: 'https://api-docs.defillama.com/',
+          target: '_blank',
+          rel: 'noopener noreferrer'
+        }, 'Defillama API'),
+        '. Made with AI & Degen Love.'
+      )
     )
   );
 }

--- a/index.html
+++ b/index.html
@@ -57,14 +57,6 @@
 <body>
     <div id="root"></div>
     
-    <!-- Persistent Footer -->
-    <footer class="app-footer">
-        <p>
-            Powered by <a href="https://api-docs.defillama.com/" target="_blank" rel="noopener noreferrer">Defillama API</a>. 
-            Made with AI & Degen Love.
-        </p>
-    </footer>
-    
     <script type="text/babel" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- Remove footer from HTML to prevent unstyled content flash
- Add footer as React component for consistent theming
- Clean up loading experience with zero layout shifts
- Improves PageSpeed performance metrics