### PR TITLE
feat: add dynamic protocol filter with user-friendly names

### DIFF
--- a/PoolDetail.js
+++ b/PoolDetail.js
@@ -1,0 +1,1053 @@
+// Standalone PoolDetail Component - Full Version
+const { useState } = React;
+
+function PoolDetail({ 
+  pool, 
+  onBack, 
+  calculateYields, 
+  formatCurrency, 
+  formatAPY,
+  getProtocolUrl,
+  getProtocolUrlWithRef,
+  isDarkMode 
+}) {
+  const [investmentAmount, setInvestmentAmount] = useState(1000);
+  const [showAPYBreakdown, setShowAPYBreakdown] = useState(false);
+  const [calculatorExpanded, setCalculatorExpanded] = useState(true);
+  const [poolInfoExpanded, setPoolInfoExpanded] = useState(false);
+  
+  if (!pool) {
+    return React.createElement('div', { className: 'pool-detail-empty' },
+      React.createElement('p', null, 'No pool selected'),
+      React.createElement('button', { 
+        className: 'back-button',
+        onClick: onBack 
+      }, '← Back to results')
+    );
+  }
+  
+  const totalApy = (pool.apyBase || 0) + (pool.apyReward || 0);
+  const yields = calculateYields(investmentAmount, totalApy);
+  const protocolUrl = getProtocolUrl(pool);
+  const protocolUrlWithRef = getProtocolUrlWithRef(pool);
+  
+  // Determine pool type
+  const getPoolType = () => {
+    if (!pool.project) return 'Yield Farming';
+    
+    const projectName = pool.project.toLowerCase();
+    
+    if (pool.poolMeta && pool.poolMeta.toLowerCase().includes('lending')) {
+      return 'Lending';
+    }
+    
+    const lendingProtocols = ['aave', 'compound', 'morpho', 'spark', 'maple', 'euler', 'radiant'];
+    const dexProtocols = ['uniswap', 'curve', 'balancer', 'pancakeswap', 'sushiswap'];
+    const stakingProtocols = ['lido', 'rocket-pool', 'ether.fi', 'jito', 'marinade'];
+    
+    if (lendingProtocols.some(p => projectName.includes(p))) return 'Lending';
+    if (dexProtocols.some(p => projectName.includes(p))) return 'LP/DEX';
+    if (stakingProtocols.some(p => projectName.includes(p))) return 'Staking';
+    
+    return 'Yield Farming';
+  };
+  
+  const poolType = getPoolType();
+  
+  return React.createElement('div', { 
+    className: 'pool-detail-container',
+    style: { 
+      opacity: 1, 
+      display: 'block', 
+      visibility: 'visible',
+      position: 'relative',
+      minHeight: '100vh',
+      padding: '40px 20px 20px 20px',
+      maxWidth: '1200px',
+      margin: '0 auto'
+    }
+  },
+    // Header with Back Button and Logo
+    React.createElement('div', { 
+      className: 'header animate-on-mount',
+      style: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '0 0 32px 0',
+        marginBottom: '32px',
+        borderBottom: '1px solid rgba(16, 185, 129, 0.1)'
+      }
+    },
+      React.createElement('div', {
+        style: {
+          display: 'flex',
+          alignItems: 'center',
+          gap: '16px'
+        }
+      },
+        // Back Button
+        React.createElement('button', { 
+          className: 'back-to-results-btn',
+          onClick: onBack,
+          style: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            padding: '10px 16px',
+            background: 'var(--color-background)',
+            border: 'none',
+            borderRadius: '12px',
+            color: 'var(--color-text)',
+            fontSize: 'var(--font-size-sm)',
+            fontWeight: 'var(--font-weight-medium)',
+            cursor: 'pointer',
+            boxShadow: 'var(--neuro-shadow-subtle)',
+            transition: 'all 0.2s ease'
+          }
+        }, 
+          React.createElement('span', { className: 'back-arrow' }, '←'),
+          React.createElement('span', null, 'Back to results')
+        ),
+        
+        // DeFi Garden Logo
+        React.createElement('h1', { 
+          className: 'logo',
+          style: {
+            fontSize: 'var(--font-size-2xl)',
+            fontWeight: 'var(--font-weight-black)',
+            color: 'var(--color-text)',
+            margin: 0,
+            cursor: 'pointer'
+          },
+          onClick: onBack
+        }, 'DeFi Garden')
+      ),
+      
+      // Pool Badge
+      React.createElement('div', {
+        className: 'pool-breadcrumb',
+        style: {
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+          padding: '8px 16px',
+          background: 'var(--color-background)',
+          borderRadius: '20px',
+          boxShadow: 'var(--neuro-shadow-pressed)',
+          fontSize: 'var(--font-size-sm)',
+          color: 'var(--color-text-secondary)'
+        }
+      },
+        React.createElement('span', null, 'Pool Details'),
+        React.createElement('span', { style: { color: 'var(--color-primary)' } }, '•'),
+        React.createElement('span', { 
+          style: { 
+            color: 'var(--color-text)',
+            fontWeight: 'var(--font-weight-semibold)'
+          } 
+        }, pool.symbol)
+      )
+    ),
+    
+    // Hero Section - Simplified and Focused
+    React.createElement('div', { 
+      className: 'pool-hero-card',
+      style: {
+        background: 'var(--color-background)',
+        borderRadius: '24px',
+        padding: '32px',
+        boxShadow: 'var(--neuro-shadow-raised)',
+        marginBottom: '24px',
+        position: 'relative',
+        overflow: 'hidden'
+      }
+    },
+      // Subtle gradient overlay
+      React.createElement('div', {
+        style: {
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          width: '40%',
+          height: '100%',
+          background: 'linear-gradient(90deg, transparent 0%, rgba(16, 185, 129, 0.03) 100%)',
+          pointerEvents: 'none'
+        }
+      }),
+      
+      // Main Hero Content
+      React.createElement('div', {
+        className: 'pool-hero-content',
+        style: {
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          position: 'relative',
+          zIndex: 1
+        }
+      },
+        // Left side - Pool info
+        React.createElement('div', { className: 'pool-info-section' },
+          React.createElement('h1', { 
+            className: 'pool-symbol-hero',
+            style: {
+              fontSize: 'var(--font-size-4xl)',
+              fontWeight: '900',
+              color: 'var(--color-text)',
+              marginBottom: '8px',
+              fontFamily: 'monospace',
+              lineHeight: '1.1'
+            }
+          }, pool.symbol),
+          
+          React.createElement('div', { 
+            className: 'pool-meta-simplified',
+            style: {
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              marginBottom: '16px',
+              fontSize: 'var(--font-size-lg)',
+              color: 'var(--color-text-secondary)'
+            }
+          },
+            React.createElement('span', { 
+              className: 'protocol-name',
+              style: { 
+                color: 'var(--color-text)',
+                fontWeight: 'var(--font-weight-semibold)'
+              }
+            }, pool.project),
+            React.createElement('span', { className: 'separator' }, '•'),
+            React.createElement('span', { 
+              className: 'chain-name',
+              style: { color: 'var(--color-primary)' }
+            }, pool.chain)
+          ),
+          
+          React.createElement('div', { 
+            className: 'pool-type-badge-hero',
+            style: {
+              display: 'inline-flex',
+              alignItems: 'center',
+              background: 'var(--color-background)',
+              color: 'var(--color-primary)',
+              padding: '8px 16px',
+              borderRadius: '20px',
+              fontSize: 'var(--font-size-sm)',
+              fontWeight: 'var(--font-weight-medium)',
+              boxShadow: 'var(--neuro-shadow-pressed)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px'
+            }
+          }, poolType),
+          
+          // Trust indicators
+          React.createElement('div', {
+            className: 'trust-indicators',
+            style: {
+              display: 'flex',
+              gap: '8px',
+              marginTop: '16px'
+            }
+          },
+            React.createElement('div', {
+              className: 'trust-badge',
+              style: {
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '4px',
+                padding: '4px 8px',
+                background: 'var(--color-background)',
+                borderRadius: '12px',
+                fontSize: 'var(--font-size-xs)',
+                color: 'var(--color-success)',
+                boxShadow: 'var(--neuro-shadow-pressed)'
+              }
+            }, '✓ Verified'),
+            React.createElement('div', {
+              className: 'tvl-badge',
+              style: {
+                display: 'inline-flex',
+                alignItems: 'center',
+                padding: '4px 8px',
+                background: 'var(--color-background)',
+                borderRadius: '12px',
+                fontSize: 'var(--font-size-xs)',
+                color: 'var(--color-text-secondary)',
+                boxShadow: 'var(--neuro-shadow-pressed)'
+              }
+            }, formatCurrency(pool.tvlUsd) + ' TVL')
+          )
+        ),
+        
+        // Right side - APY and CTA
+        React.createElement('div', { 
+          className: 'apy-cta-section',
+          style: {
+            textAlign: 'right',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-end',
+            gap: '16px'
+          }
+        },
+          React.createElement('div', {
+            className: 'apy-display-hero',
+            style: {
+              display: 'inline-flex',
+              flexDirection: 'column',
+              alignItems: 'flex-end',
+              padding: '20px 24px',
+              background: 'var(--color-background)',
+              borderRadius: '16px',
+              boxShadow: 'var(--neuro-shadow-pressed)',
+              minWidth: '180px'
+            }
+          },
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-sm)',
+                color: 'var(--color-text-secondary)',
+                marginBottom: '4px',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+                fontWeight: 'var(--font-weight-medium)'
+              }
+            }, 'Total APY'),
+            React.createElement('div', {
+              className: 'apy-value-hero',
+              style: {
+                fontSize: 'var(--font-size-3xl)',
+                fontWeight: '900',
+                background: 'linear-gradient(135deg, var(--color-primary) 0%, var(--color-forest) 100%)',
+                WebkitBackgroundClip: 'text',
+                WebkitTextFillColor: 'transparent',
+                backgroundClip: 'text',
+                lineHeight: '1.1'
+              }
+            }, formatAPY(pool.apyBase, pool.apyReward))
+          ),
+          
+          protocolUrlWithRef && React.createElement('button', {
+            className: 'cta-button-primary',
+            onClick: () => window.open(protocolUrlWithRef, '_blank', 'noopener,noreferrer'),
+            style: {
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '8px',
+              padding: '14px 28px',
+              background: 'var(--color-primary)',
+              color: 'white',
+              border: 'none',
+              borderRadius: '12px',
+              fontSize: 'var(--font-size-base)',
+              fontWeight: 'var(--font-weight-bold)',
+              cursor: 'pointer',
+              transition: 'all 0.3s ease',
+              boxShadow: 'var(--neuro-shadow-raised)',
+              position: 'relative',
+              overflow: 'hidden'
+            }
+          },
+            React.createElement('span', null, 'Start Earning'),
+            React.createElement('span', {
+              className: 'arrow',
+              style: {
+                transition: 'transform 0.2s ease'
+              }
+            }, '→')
+          )
+        )
+      )
+    ),
+    
+    // Quick Metrics - Simplified 3-card layout
+    React.createElement('div', { 
+      className: 'quick-metrics',
+      style: {
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+        gap: '16px',
+        marginBottom: '40px'
+      }
+    },
+      React.createElement('div', { 
+        className: 'metric-card-simple',
+        style: {
+          background: 'var(--color-background)',
+          borderRadius: '16px',
+          padding: '20px',
+          boxShadow: 'var(--neuro-shadow-subtle)',
+          textAlign: 'center',
+          transition: 'all 0.3s ease'
+        }
+      },
+        React.createElement('div', {
+          style: {
+            fontSize: 'var(--font-size-sm)',
+            color: 'var(--color-text-secondary)',
+            marginBottom: '8px',
+            fontWeight: 'var(--font-weight-medium)'
+          }
+        }, 'Daily ($1000)'),
+        React.createElement('div', {
+          style: {
+            fontSize: 'var(--font-size-xl)',
+            fontWeight: 'var(--font-weight-bold)',
+            color: 'var(--color-primary)'
+          }
+        }, `$${(1000 * totalApy / 365 / 100).toFixed(2)}`)
+      ),
+      
+      React.createElement('div', { 
+        className: 'metric-card-simple',
+        style: {
+          background: 'var(--color-background)',
+          borderRadius: '16px',
+          padding: '20px',
+          boxShadow: 'var(--neuro-shadow-subtle)',
+          textAlign: 'center',
+          transition: 'all 0.3s ease'
+        }
+      },
+        React.createElement('div', {
+          style: {
+            fontSize: 'var(--font-size-sm)',
+            color: 'var(--color-text-secondary)',
+            marginBottom: '8px',
+            fontWeight: 'var(--font-weight-medium)'
+          }
+        }, 'Monthly ($1000)'),
+        React.createElement('div', {
+          style: {
+            fontSize: 'var(--font-size-xl)',
+            fontWeight: 'var(--font-weight-bold)',
+            color: 'var(--color-text)'
+          }
+        }, `$${(1000 * totalApy / 12 / 100).toFixed(2)}`)
+      ),
+      
+      React.createElement('div', { 
+        className: 'metric-card-simple risk-card',
+        style: {
+          background: 'var(--color-background)',
+          borderRadius: '16px',
+          padding: '20px',
+          boxShadow: 'var(--neuro-shadow-subtle)',
+          textAlign: 'center',
+          transition: 'all 0.3s ease'
+        }
+      },
+        React.createElement('div', {
+          style: {
+            fontSize: 'var(--font-size-sm)',
+            color: 'var(--color-text-secondary)',
+            marginBottom: '8px',
+            fontWeight: 'var(--font-weight-medium)'
+          }
+        }, 'Risk Level'),
+        React.createElement('div', {
+          style: {
+            fontSize: 'var(--font-size-lg)',
+            fontWeight: 'var(--font-weight-bold)',
+            color: pool.tvlUsd > 10000000 ? 'var(--color-success)' : pool.tvlUsd > 1000000 ? 'var(--color-warning)' : 'var(--color-error)'
+          }
+        }, pool.tvlUsd > 10000000 ? 'Low' : pool.tvlUsd > 1000000 ? 'Medium' : 'High')
+      )
+    ),
+    
+    // Collapsible Yield Calculator
+    React.createElement('div', { 
+      className: `calculator-compact ${calculatorExpanded ? 'expanded' : ''}`,
+      style: {
+        background: 'var(--color-background)',
+        borderRadius: '16px',
+        padding: calculatorExpanded ? '24px' : '20px',
+        boxShadow: calculatorExpanded ? 'var(--neuro-shadow-raised)' : 'var(--neuro-shadow-pressed)',
+        marginBottom: '32px',
+        transition: 'all 0.3s ease'
+      }
+    },
+      // Calculator Header
+      React.createElement('div', {
+        className: 'calculator-header',
+        onClick: () => setCalculatorExpanded(!calculatorExpanded),
+        style: {
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          cursor: 'pointer',
+          marginBottom: calculatorExpanded ? '24px' : '0'
+        }
+      },
+        React.createElement('div', {
+          style: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px'
+          }
+        },
+          React.createElement('span', {
+            style: {
+              fontSize: 'var(--font-size-2xl)'
+            }
+          }, '💰'),
+          React.createElement('div', null,
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-lg)',
+                fontWeight: 'var(--font-weight-bold)',
+                color: 'var(--color-text)'
+              }
+            }, 'Calculate Your Earnings'),
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-sm)',
+                color: 'var(--color-text-secondary)',
+                marginTop: '2px'
+              }
+            }, `Quick estimate for $${investmentAmount}: $${(investmentAmount * totalApy / 365 / 100).toFixed(2)}/day`)
+          )
+        ),
+        React.createElement('div', {
+          className: 'calculator-toggle',
+          style: {
+            width: '32px',
+            height: '32px',
+            borderRadius: '50%',
+            background: 'var(--color-background)',
+            boxShadow: 'var(--neuro-shadow-subtle)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            transition: 'transform 0.3s ease',
+            transform: calculatorExpanded ? 'rotate(180deg)' : 'rotate(0deg)'
+          }
+        }, '▼')
+      ),
+      
+      // Expanded Calculator Content
+      calculatorExpanded && React.createElement('div', {
+        className: 'calculator-content',
+        style: {
+          animation: 'fadeIn 0.3s ease'
+        }
+      },
+        // Investment Input
+        React.createElement('div', { 
+          className: 'investment-input-group',
+          style: {
+            marginBottom: '24px',
+            textAlign: 'center'
+          }
+        },
+          React.createElement('div', { 
+            className: 'input-wrapper',
+            style: {
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '8px',
+              marginBottom: '16px'
+            }
+          },
+            React.createElement('span', {
+              style: {
+                fontSize: 'var(--font-size-lg)',
+                fontWeight: 'var(--font-weight-bold)',
+                color: 'var(--color-text-secondary)'
+              }
+            }, '$'),
+            React.createElement('input', {
+              type: 'number',
+              className: 'amount-input',
+              value: investmentAmount,
+              onChange: (e) => setInvestmentAmount(Number(e.target.value) || 0),
+              min: '0',
+              step: '100',
+              style: {
+                width: '180px',
+                padding: '12px 16px',
+                border: 'none',
+                borderRadius: '12px',
+                background: 'var(--color-background)',
+                color: 'var(--color-text)',
+                fontSize: 'var(--font-size-lg)',
+                fontWeight: 'var(--font-weight-medium)',
+                textAlign: 'center',
+                boxShadow: 'var(--neuro-shadow-pressed)',
+                outline: 'none'
+              }
+            })
+          ),
+          
+          // Quick Amount Buttons
+          React.createElement('div', { 
+            style: {
+              display: 'flex',
+              gap: '8px',
+              justifyContent: 'center',
+              flexWrap: 'wrap'
+            }
+          },
+            [100, 1000, 5000, 10000].map(amount => 
+              React.createElement('button', {
+                key: amount,
+                onClick: () => setInvestmentAmount(amount),
+                style: {
+                  padding: '6px 12px',
+                  border: 'none',
+                  background: investmentAmount === amount ? 'var(--color-primary)' : 'var(--color-background)',
+                  color: investmentAmount === amount ? 'white' : 'var(--color-text-secondary)',
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  fontSize: 'var(--font-size-sm)',
+                  fontWeight: 'var(--font-weight-medium)',
+                  boxShadow: investmentAmount === amount ? 'var(--neuro-shadow-pressed)' : 'var(--neuro-shadow-subtle)',
+                  transition: 'all 0.2s ease'
+                }
+              }, `$${amount >= 1000 ? `${amount/1000}k` : amount}`)
+            )
+          )
+        ),
+        
+        // Compact Yield Results
+        React.createElement('div', { 
+          style: {
+            display: 'grid',
+            gridTemplateColumns: 'repeat(2, 1fr)',
+            gap: '12px',
+            marginBottom: '16px'
+          }
+        },
+          React.createElement('div', { 
+            style: {
+              background: 'var(--color-background)',
+              borderRadius: '12px',
+              padding: '16px',
+              textAlign: 'center',
+              boxShadow: 'var(--neuro-shadow-subtle)'
+            }
+          },
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-sm)',
+                color: 'var(--color-text-secondary)',
+                marginBottom: '4px'
+              }
+            }, '24 Hours'),
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-lg)',
+                fontWeight: 'var(--font-weight-bold)',
+                color: 'var(--color-primary)'
+              }
+            }, `$${yields.oneDayGain.toFixed(2)}`)
+          ),
+          
+          React.createElement('div', { 
+            style: {
+              background: 'var(--color-background)',
+              borderRadius: '12px',
+              padding: '16px',
+              textAlign: 'center',
+              boxShadow: 'var(--neuro-shadow-subtle)'
+            }
+          },
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-sm)',
+                color: 'var(--color-text-secondary)',
+                marginBottom: '4px'
+              }
+            }, '30 Days'),
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-lg)',
+                fontWeight: 'var(--font-weight-bold)',
+                color: 'var(--color-text)'
+              }
+            }, `$${(investmentAmount * totalApy / 12 / 100).toFixed(2)}`)
+          ),
+          
+          React.createElement('div', { 
+            style: {
+              background: 'var(--color-background)',
+              borderRadius: '12px',
+              padding: '16px',
+              textAlign: 'center',
+              boxShadow: 'var(--neuro-shadow-subtle)'
+            }
+          },
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-sm)',
+                color: 'var(--color-text-secondary)',
+                marginBottom: '4px'
+              }
+            }, '1 Year'),
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-lg)',
+                fontWeight: 'var(--font-weight-bold)',
+                color: 'var(--color-success)'
+              }
+            }, `$${(investmentAmount * totalApy / 100).toFixed(2)}`)
+          ),
+          
+          React.createElement('div', { 
+            style: {
+              background: 'var(--color-background)',
+              borderRadius: '12px',
+              padding: '16px',
+              textAlign: 'center',
+              boxShadow: 'var(--neuro-shadow-subtle)'
+            }
+          },
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-sm)',
+                color: 'var(--color-text-secondary)',
+                marginBottom: '4px'
+              }
+            }, 'Compounding'),
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-lg)',
+                fontWeight: 'var(--font-weight-bold)',
+                color: 'var(--color-success)'
+              }
+            }, `$${(investmentAmount * Math.pow(1 + totalApy/100/365, 365) - investmentAmount).toFixed(2)}`)
+          )
+        ),
+        
+        React.createElement('div', { 
+          style: {
+            fontSize: 'var(--font-size-xs)',
+            color: 'var(--color-text-secondary)',
+            textAlign: 'center',
+            fontStyle: 'italic',
+            padding: '12px',
+            background: 'rgba(16, 185, 129, 0.05)',
+            borderRadius: '8px',
+            borderLeft: '3px solid var(--color-primary)'
+          }
+        }, 'Calculations are estimates. Actual yields may vary based on market conditions.')
+      )
+    ),
+    
+    // Collapsible Pool Information
+    React.createElement('div', { 
+      className: `pool-info-section ${poolInfoExpanded ? 'expanded' : ''}`,
+      style: {
+        background: 'var(--color-background)',
+        borderRadius: '16px',
+        padding: poolInfoExpanded ? '24px' : '20px',
+        boxShadow: poolInfoExpanded ? 'var(--neuro-shadow-raised)' : 'var(--neuro-shadow-pressed)',
+        marginBottom: '32px',
+        transition: 'all 0.3s ease'
+      }
+    },
+      // Pool Info Header
+      React.createElement('div', {
+        className: 'pool-info-header',
+        onClick: () => setPoolInfoExpanded(!poolInfoExpanded),
+        style: {
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          cursor: 'pointer',
+          marginBottom: poolInfoExpanded ? '20px' : '0'
+        }
+      },
+        React.createElement('div', {
+          style: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px'
+          }
+        },
+          React.createElement('span', {
+            style: {
+              fontSize: 'var(--font-size-lg)'
+            }
+          }, '📊'),
+          React.createElement('h3', {
+            style: {
+              fontSize: 'var(--font-size-lg)',
+              fontWeight: 'var(--font-weight-bold)',
+              color: 'var(--color-text)',
+              margin: 0
+            }
+          }, 'Pool Information'),
+          protocolUrl && React.createElement('a', {
+            href: protocolUrl,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+            onClick: (e) => e.stopPropagation(),
+            style: {
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '4px',
+              padding: '4px 8px',
+              background: 'var(--color-background)',
+              color: 'var(--color-primary)',
+              textDecoration: 'none',
+              borderRadius: '6px',
+              fontSize: 'var(--font-size-xs)',
+              fontWeight: 'var(--font-weight-medium)',
+              boxShadow: 'var(--neuro-shadow-subtle)',
+              transition: 'all 0.2s ease'
+            }
+          }, 'Protocol', '↗')
+        ),
+        React.createElement('div', {
+          className: 'pool-info-toggle',
+          style: {
+            width: '28px',
+            height: '28px',
+            borderRadius: '50%',
+            background: 'var(--color-background)',
+            boxShadow: 'var(--neuro-shadow-subtle)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            transition: 'transform 0.3s ease',
+            transform: poolInfoExpanded ? 'rotate(180deg)' : 'rotate(0deg)'
+          }
+        }, '▼')
+      ),
+      
+      // Expanded Pool Information Content
+      poolInfoExpanded && React.createElement('div', {
+        className: 'pool-info-content',
+        style: {
+          animation: 'fadeIn 0.3s ease'
+        }
+      },
+        // APY Breakdown Grid
+        React.createElement('div', {
+        style: {
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+          gap: '12px',
+          marginBottom: '20px'
+        }
+      },
+        // APY Breakdown
+        (pool.apyBase > 0 && pool.apyReward > 0) && React.createElement('div', {
+          style: {
+            padding: '12px',
+            background: 'var(--color-background)',
+            borderRadius: '8px',
+            boxShadow: 'var(--neuro-shadow-subtle)',
+            textAlign: 'center'
+          }
+        },
+          React.createElement('div', {
+            style: {
+              fontSize: 'var(--font-size-xs)',
+              color: 'var(--color-text-secondary)',
+              marginBottom: '4px',
+              textTransform: 'uppercase'
+            }
+          }, 'Base APY'),
+          React.createElement('div', {
+            style: {
+              fontSize: 'var(--font-size-base)',
+              fontWeight: 'var(--font-weight-bold)',
+              color: 'var(--color-text)'
+            }
+          }, `${pool.apyBase.toFixed(1)}%`)
+        ),
+        
+        (pool.apyBase > 0 && pool.apyReward > 0) && React.createElement('div', {
+          style: {
+            padding: '12px',
+            background: 'var(--color-background)',
+            borderRadius: '8px',
+            boxShadow: 'var(--neuro-shadow-subtle)',
+            textAlign: 'center'
+          }
+        },
+          React.createElement('div', {
+            style: {
+              fontSize: 'var(--font-size-xs)',
+              color: 'var(--color-text-secondary)',
+              marginBottom: '4px',
+              textTransform: 'uppercase'
+            }
+          }, 'Reward APY'),
+          React.createElement('div', {
+            style: {
+              fontSize: 'var(--font-size-base)',
+              fontWeight: 'var(--font-weight-bold)',
+              color: 'var(--color-primary)'
+            }
+          }, `${pool.apyReward.toFixed(1)}%`)
+        ),
+        
+        // Pool Age (if available)
+        React.createElement('div', {
+          style: {
+            padding: '12px',
+            background: 'var(--color-background)',
+            borderRadius: '8px',
+            boxShadow: 'var(--neuro-shadow-subtle)',
+            textAlign: 'center'
+          }
+        },
+          React.createElement('div', {
+            style: {
+              fontSize: 'var(--font-size-xs)',
+              color: 'var(--color-text-secondary)',
+              marginBottom: '4px',
+              textTransform: 'uppercase'
+            }
+          }, 'Pool Type'),
+          React.createElement('div', {
+            style: {
+              fontSize: 'var(--font-size-sm)',
+              fontWeight: 'var(--font-weight-medium)',
+              color: 'var(--color-text)'
+            }
+          }, poolType)
+        )
+      ),
+      
+      // Tokens Section (if available)
+      (pool.underlyingTokens && pool.underlyingTokens.length > 0) && 
+        React.createElement('div', {
+          style: {
+            marginTop: '16px',
+            paddingTop: '16px',
+            borderTop: '1px solid rgba(16, 185, 129, 0.1)'
+          }
+        },
+          React.createElement('div', {
+            style: {
+              fontSize: 'var(--font-size-sm)',
+              color: 'var(--color-text-secondary)',
+              marginBottom: '8px',
+              fontWeight: 'var(--font-weight-medium)'
+            }
+          }, 'Underlying Assets'),
+          React.createElement('div', {
+            style: {
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: '6px'
+            }
+          },
+            pool.underlyingTokens.map((token, idx) => {
+              const isAddress = typeof token === 'string' && token.startsWith('0x') && token.length >= 40;
+              
+              if (isAddress) {
+                return React.createElement('a', {
+                  key: idx,
+                  href: `https://blockscan.com/address/${token}`,
+                  target: '_blank',
+                  rel: 'noopener noreferrer',
+                  style: {
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    padding: '6px 10px',
+                    background: 'var(--color-background)',
+                    color: 'var(--color-primary)',
+                    borderRadius: '8px',
+                    fontSize: 'var(--font-size-xs)',
+                    fontWeight: 'var(--font-weight-medium)',
+                    boxShadow: 'var(--neuro-shadow-subtle)',
+                    textDecoration: 'none',
+                    transition: 'all 0.2s ease',
+                    fontFamily: 'monospace'
+                  }
+                }, `${token.slice(0, 6)}...${token.slice(-4)} ↗`);
+              }
+              
+              return React.createElement('span', {
+                key: idx,
+                style: {
+                  padding: '6px 10px',
+                  background: 'var(--color-background)',
+                  color: 'var(--color-text)',
+                  borderRadius: '8px',
+                  fontSize: 'var(--font-size-xs)',
+                  fontWeight: 'var(--font-weight-medium)',
+                  boxShadow: 'var(--neuro-shadow-subtle)'
+                }
+              }, token);
+            })
+          )
+        )
+      )
+    ),
+    
+    // Compact Risk & Legal Section
+    React.createElement('div', { 
+      className: 'risk-disclaimer-compact',
+      style: {
+        background: 'var(--color-background)',
+        border: '1px solid rgba(255, 193, 7, 0.2)',
+        borderRadius: '12px',
+        padding: '16px',
+        boxShadow: 'var(--neuro-shadow-pressed)'
+      }
+    },
+      React.createElement('div', {
+        style: {
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: '12px'
+        }
+      },
+        React.createElement('span', {
+          style: {
+            fontSize: 'var(--font-size-lg)',
+            marginTop: '2px'
+          }
+        }, '⚠️'),
+        React.createElement('div', null,
+          React.createElement('div', {
+            style: {
+              fontSize: 'var(--font-size-base)',
+              fontWeight: 'var(--font-weight-bold)',
+              color: '#ff6b35',
+              marginBottom: '6px'
+            }
+          }, 'Important Risk Information'),
+          React.createElement('p', {
+            style: {
+              fontSize: 'var(--font-size-sm)',
+              color: 'var(--color-text-secondary)',
+              lineHeight: '1.4',
+              margin: '0'
+            }
+          }, 'DeFi investments carry risks including smart contract vulnerabilities and market volatility. Only invest what you can afford to lose.')
+        )
+      )
+    ) // End of risk disclaimer
+  );
+}
+
+// Simple fade-in animation for calculator
+const fadeInStyles = `
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+`;
+
+// Inject animation styles
+if (typeof document !== 'undefined') {
+  const styleSheet = document.createElement('style');
+  styleSheet.textContent = fadeInStyles;
+  document.head.appendChild(styleSheet);
+}
+
+// Export for use in main app
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = PoolDetail;
+}

--- a/app.js
+++ b/app.js
@@ -296,6 +296,102 @@ const getChainColor = (chainName) => {
   return chainColors[chainName] || '#6B7280'; // Default gray color
 };
 
+// Helper function to get friendly protocol names
+const getFriendlyProtocolName = (protocolName) => {
+  if (!protocolName) return protocolName;
+  
+  const protocolNameMap = {
+    // Aave variants
+    'aave-v2': 'Aave',
+    'aave-v3': 'Aave',
+    'aave': 'Aave',
+    
+    // Compound variants
+    'compound-v2': 'Compound',
+    'compound-v3': 'Compound',
+    'compound': 'Compound',
+    
+    // Uniswap variants
+    'uniswap-v2': 'Uniswap',
+    'uniswap-v3': 'Uniswap',
+    'uniswap': 'Uniswap',
+    
+    // Curve variants
+    'curve-dex': 'Curve',
+    'curve': 'Curve',
+    
+    // Balancer variants
+    'balancer-v2': 'Balancer',
+    'balancer': 'Balancer',
+    
+    // PancakeSwap variants
+    'pancakeswap-v2': 'PancakeSwap',
+    'pancakeswap-v3': 'PancakeSwap',
+    'pancakeswap-amm': 'PancakeSwap',
+    'pancakeswap': 'PancakeSwap',
+    
+    // Aerodrome variants
+    'aerodrome-slipstream': 'Aerodrome',
+    'aerodrome': 'Aerodrome',
+    
+    // Morpho variants
+    'morpho-blue': 'Morpho',
+    'morpho': 'Morpho',
+    
+    // Lido variants
+    'lido': 'Lido',
+    
+    // Rocket Pool variants
+    'rocket-pool': 'Rocket Pool',
+    'rocketpool': 'Rocket Pool',
+    
+    // Ether.fi variants
+    'ether.fi-stake': 'Ether.fi',
+    'ether.fi': 'Ether.fi',
+    
+    // Jito variants
+    'jito-liquid-staking': 'Jito',
+    'jito': 'Jito',
+    
+    // Yearn variants
+    'yearn-finance': 'Yearn',
+    'yearn': 'Yearn',
+    
+    // Convex variants
+    'convex-finance': 'Convex',
+    'convex': 'Convex',
+    
+    // GMX variants
+    'gmx-v2-perps': 'GMX',
+    'gmx': 'GMX',
+    
+    // Camelot variants
+    'camelot-v2': 'Camelot',
+    'camelot-v3': 'Camelot',
+    'camelot': 'Camelot',
+    
+    // Venus variants
+    'venus-core-pool': 'Venus',
+    'venus': 'Venus',
+    
+    // Pendle variants
+    'pendle': 'Pendle',
+    
+    // Raydium variants
+    'raydium': 'Raydium',
+    
+    // Orca variants
+    'orca': 'Orca',
+    
+    // Marinade variants
+    'marinade': 'Marinade'
+  };
+  
+  // Return mapped name or capitalize first letter of original
+  return protocolNameMap[protocolName.toLowerCase()] || 
+         protocolName.charAt(0).toUpperCase() + protocolName.slice(1).replace(/-/g, ' ');
+};
+
 // Main App Component
 function App() {
   const [pools, setPools] = useState([]);
@@ -304,6 +400,7 @@ function App() {
   const [searchInput, setSearchInput] = useState('');
   const [selectedChain, setSelectedChain] = useState('');
   const [selectedPoolTypes, setSelectedPoolTypes] = useState([]); // Changed to array for multi-select
+  const [selectedProtocols, setSelectedProtocols] = useState([]); // New state for protocol filtering
   const [minTvl, setMinTvl] = useState(0);
   const [minApy, setMinApy] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
@@ -327,6 +424,8 @@ function App() {
   const [dynamicProtocolUrls, setDynamicProtocolUrls] = useState({});
   const [animationsTriggered, setAnimationsTriggered] = useState(false);
   const [chainMode, setChainMode] = useState(false); // Track if we're in chain-first mode
+  const [currentView, setCurrentView] = useState('search'); // 'search' or 'pool-detail'
+  const [detailPool, setDetailPool] = useState(null); // Pool being viewed in detail
 
   const debouncedSearchInput = useDebounce(searchInput, 300);
   const itemsPerPage = 10;
@@ -335,20 +434,24 @@ function App() {
   const getUrlParams = () => {
     const params = new URLSearchParams(window.location.search);
     const poolTypesParam = params.get('poolTypes');
+    const protocolsParam = params.get('protocols');
     return {
       token: params.get('token') || '',
       chain: params.get('chain') || '',
       poolTypes: poolTypesParam ? poolTypesParam.split(',') : [],
+      protocols: protocolsParam ? protocolsParam.split(',') : [],
       minTvl: parseInt(params.get('minTvl') || '0', 10),
-      minApy: parseInt(params.get('minApy') || '0', 10)
+      minApy: parseInt(params.get('minApy') || '0', 10),
+      pool: params.get('pool') || ''
     };
   };
 
-  const updateUrl = (token, chain, poolTypes, minTvl, minApy) => {
+  const updateUrl = (token, chain, poolTypes, protocols, minTvl, minApy) => {
     const params = new URLSearchParams();
     if (token) params.set('token', token);
     if (chain) params.set('chain', chain);
     if (poolTypes && poolTypes.length > 0) params.set('poolTypes', poolTypes.join(','));
+    if (protocols && protocols.length > 0) params.set('protocols', protocols.join(','));
     if (minTvl > 0) params.set('minTvl', minTvl.toString());
     if (minApy > 0) params.set('minApy', minApy.toString());
     
@@ -387,6 +490,7 @@ function App() {
     
     if (urlParams.chain) setSelectedChain(urlParams.chain);
     if (urlParams.poolTypes) setSelectedPoolTypes(urlParams.poolTypes);
+    if (urlParams.protocols) setSelectedProtocols(urlParams.protocols);
     if (urlParams.minTvl) setMinTvl(urlParams.minTvl);
     if (urlParams.minApy) setMinApy(urlParams.minApy);
     
@@ -400,6 +504,15 @@ function App() {
   // Handle browser back/forward navigation
   useEffect(() => {
     const handlePopState = () => {
+      const params = new URLSearchParams(window.location.search);
+      const poolParam = params.get('pool');
+      
+      // Check if we're navigating away from pool detail view
+      if (!poolParam && currentView === 'pool-detail') {
+        setCurrentView('search');
+        setDetailPool(null);
+      }
+      
       const urlParams = getUrlParams();
       
       // Determine mode based on URL parameters
@@ -431,6 +544,7 @@ function App() {
       }
       
       setSelectedPoolTypes(urlParams.poolTypes);
+      setSelectedProtocols(urlParams.protocols);
       setMinApy(urlParams.minApy);
       setShowAutocomplete(false);
       setHighlightedIndex(-1);
@@ -438,7 +552,7 @@ function App() {
 
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
-  }, []);
+  }, [currentView]);
   // Background fetch pools data after UI loads
   useEffect(() => {
     const fetchPoolsInBackground = async () => {
@@ -462,6 +576,26 @@ function App() {
     setLoading(true);
     fetchPoolsInBackground();
   }, []);
+
+  // Handle pool detail URL parameter after pools are loaded
+  useEffect(() => {
+    if (pools.length > 0 && !detailPool) {
+      const urlParams = getUrlParams();
+      if (urlParams.pool) {
+        // Find the pool by ID
+        const foundPool = pools.find(pool => 
+          pool.pool === urlParams.pool || 
+          `${pool.project}-${pool.symbol}-${pool.chain}` === decodeURIComponent(urlParams.pool)
+        );
+        
+        if (foundPool) {
+          setDetailPool(foundPool);
+          setCurrentView('pool-detail');
+          document.title = `${foundPool.symbol} on ${foundPool.project} | DeFi Garden 🌱`;
+        }
+      }
+    }
+  }, [pools, detailPool]);
 
   // Background fetch protocols data after UI loads
   useEffect(() => {
@@ -681,6 +815,69 @@ function App() {
   }, [selectedToken, pools, chainMode]);
 
 
+  // Get available protocols for selected token or chain (dynamically from current pools)
+  const availableProtocols = useMemo(() => {
+    if (!pools.length) return { popular: [], all: [] };
+    
+    const protocolStats = {};
+    
+    pools.forEach(pool => {
+      if (!pool.project || !pool.tvlUsd || pool.tvlUsd <= 0) return;
+      
+      let includePool = false;
+      
+      // Chain mode: include pools on selected chain
+      if (chainMode && selectedChain && !selectedToken) {
+        includePool = pool.chain === selectedChain;
+      }
+      // Token mode: include pools with selected token
+      else if (selectedToken && pool.symbol) {
+        const symbols = pool.symbol.split(/[-_\/\s]/).map(s => s.trim().toUpperCase());
+        includePool = symbols.some(symbol => symbol === selectedToken.toUpperCase());
+        
+        // Also check chain filter if both token and chain are selected
+        if (includePool && selectedChain) {
+          includePool = pool.chain === selectedChain;
+        }
+      }
+      
+      if (includePool) {
+        // Get friendly name and group protocols with same friendly name
+        const friendlyName = getFriendlyProtocolName(pool.project);
+        
+        if (!protocolStats[friendlyName]) {
+          protocolStats[friendlyName] = {
+            friendlyName: friendlyName,
+            originalNames: new Set([pool.project]), // Keep track of original names for filtering
+            poolCount: 0,
+            totalTvl: 0
+          };
+        } else {
+          protocolStats[friendlyName].originalNames.add(pool.project);
+        }
+        
+        protocolStats[friendlyName].poolCount++;
+        protocolStats[friendlyName].totalTvl += pool.tvlUsd;
+      }
+    });
+    
+    // Convert originalNames Set to Array and sort protocols by TVL descending
+    const allProtocols = Object.values(protocolStats)
+      .map(protocol => ({
+        ...protocol,
+        originalNames: Array.from(protocol.originalNames)
+      }))
+      .sort((a, b) => b.totalTvl - a.totalTvl);
+    
+    // Get top 5 as "popular"
+    const popular = allProtocols.slice(0, 5);
+    
+    return {
+      popular,
+      all: allProtocols
+    };
+  }, [selectedToken, selectedChain, chainMode, pools]);
+
   // Get pool type counts for selected token or chain (before other filters)
   const poolTypeCounts = useMemo(() => {
     if (!pools.length) return {};
@@ -716,6 +913,14 @@ function App() {
 
   // Filter and sort pools when token, chain, TVL, or APY selection changes
   useEffect(() => {
+    console.log('Filter effect running - currentView:', currentView, 'selectedToken:', selectedToken, 'chainMode:', chainMode, 'selectedChain:', selectedChain);
+    
+    // Don't run filtering logic when in pool detail view
+    if (currentView === 'pool-detail') {
+      console.log('Skipping filter effect - in pool detail view');
+      return;
+    }
+    
     // Chain-first mode: filter by chain only
     if (chainMode && selectedChain && !selectedToken) {
       let filtered = pools.filter(pool => {
@@ -725,6 +930,14 @@ function App() {
         // Filter by pool type if selected
         const poolTypeMatch = selectedPoolTypes.length === 0 || selectedPoolTypes.includes(getPoolType(pool));
         
+        // Filter by protocol if selected (check against friendly names)
+        const protocolMatch = selectedProtocols.length === 0 || 
+          selectedProtocols.some(selectedProtocol => {
+            // Find the protocol object with matching friendly name
+            const protocolObj = availableProtocols.all.find(p => p.friendlyName === selectedProtocol);
+            return protocolObj && protocolObj.originalNames.includes(pool.project);
+          });
+        
         // Filter by minimum TVL
         const tvlMatch = pool.tvlUsd >= minTvl;
         
@@ -732,7 +945,7 @@ function App() {
         const totalApy = (pool.apyBase || 0) + (pool.apyReward || 0);
         const apyMatch = totalApy >= minApy;
         
-        return chainMatch && poolTypeMatch && tvlMatch && apyMatch && pool.tvlUsd > 0;
+        return chainMatch && poolTypeMatch && protocolMatch && tvlMatch && apyMatch && pool.tvlUsd > 0;
       });
 
       // Sort by total APY (base + reward) descending
@@ -766,6 +979,14 @@ function App() {
       // Filter by pool type if selected
       const poolTypeMatch = selectedPoolTypes.length === 0 || selectedPoolTypes.includes(getPoolType(pool));
       
+      // Filter by protocol if selected (check against friendly names)
+      const protocolMatch = selectedProtocols.length === 0 || 
+        selectedProtocols.some(selectedProtocol => {
+          // Find the protocol object with matching friendly name
+          const protocolObj = availableProtocols.all.find(p => p.friendlyName === selectedProtocol);
+          return protocolObj && protocolObj.originalNames.includes(pool.project);
+        });
+      
       // Filter by minimum TVL
       const tvlMatch = pool.tvlUsd >= minTvl;
       
@@ -773,7 +994,7 @@ function App() {
       const totalApy = (pool.apyBase || 0) + (pool.apyReward || 0);
       const apyMatch = totalApy >= minApy;
       
-      return hasToken && chainMatch && poolTypeMatch && tvlMatch && apyMatch && pool.tvlUsd > 0;
+      return hasToken && chainMatch && poolTypeMatch && protocolMatch && tvlMatch && apyMatch && pool.tvlUsd > 0;
     });
 
     // Sort by total APY (base + reward) descending
@@ -785,20 +1006,20 @@ function App() {
 
     setFilteredPools(filtered);
     setCurrentPage(1); // Reset to first page when filters change
-  }, [selectedToken, selectedChain, selectedPoolTypes, minTvl, minApy, pools, chainMode]);
+  }, [selectedToken, selectedChain, selectedPoolTypes, selectedProtocols, minTvl, minApy, pools, chainMode]);
 
-  // Update URL when filters change (but not during initial load or popstate events)
+  // Update URL when filters change (but not during initial load, popstate events, or pool detail view)
   useEffect(() => {
-    if (!isInitialLoad) {
+    if (!isInitialLoad && currentView !== 'pool-detail') {
       if (chainMode && selectedChain && !selectedToken) {
         // Chain-first mode URL updates
-        updateUrl('', selectedChain, selectedPoolTypes, minTvl, minApy);
+        updateUrl('', selectedChain, selectedPoolTypes, selectedProtocols, minTvl, minApy);
       } else if (selectedToken) {
         // Token-first mode URL updates
-        updateUrl(selectedToken, selectedChain, selectedPoolTypes, minTvl, minApy);
+        updateUrl(selectedToken, selectedChain, selectedPoolTypes, selectedProtocols, minTvl, minApy);
       }
     }
-  }, [selectedToken, selectedChain, selectedPoolTypes, minTvl, minApy, isInitialLoad, chainMode]);
+  }, [selectedToken, selectedChain, selectedPoolTypes, selectedProtocols, minTvl, minApy, isInitialLoad, chainMode, currentView]);
   // Handle chain selection for chain-first mode
   const handleChainSelect = (chainName) => {
     setChainMode(true);
@@ -819,7 +1040,7 @@ function App() {
     }
     
     // Update URL for chain-first mode
-    updateUrl('', chainName, selectedPoolTypes, 100000, minApy);
+    updateUrl('', chainName, selectedPoolTypes, selectedProtocols, 100000, minApy);
     
     // Scroll to results on mobile
     const isMobile = window.matchMedia('(max-width: 768px)').matches;
@@ -887,6 +1108,7 @@ function App() {
       setFilteredPools([]);
       setSelectedChain('');
       setSelectedPoolTypes([]);
+      setSelectedProtocols([]);
       setShowFilters(false);
     }
     
@@ -975,6 +1197,7 @@ function App() {
     setSearchInput('');
     setSelectedChain('');
     setSelectedPoolTypes([]);
+    setSelectedProtocols([]);
     setMinTvl(0);
     setMinApy(0);
     setFilteredPools([]);
@@ -984,6 +1207,8 @@ function App() {
     setHighlightedIndex(-1);
     setError('');
     setChainMode(false);
+    setCurrentView('search');
+    setDetailPool(null);
     
     // Clear URL parameters and reset title
     window.history.pushState({}, '', window.location.pathname);
@@ -1050,12 +1275,50 @@ function App() {
 
   const totalPages = Math.ceil(filteredPools.length / itemsPerPage);
 
-  // Handle pool click to open yield calculator
+  // Handle pool click to navigate to pool detail page
   const handlePoolClick = (pool, e) => {
     e.preventDefault();
     e.stopPropagation();
-    setSelectedPool(pool);
-    setShowYieldCalculator(true);
+    
+    console.log('handlePoolClick called for:', pool.symbol);
+    // Set the pool for detail view
+    setDetailPool(pool);
+    setCurrentView('pool-detail');
+    console.log('Set currentView to pool-detail, detailPool to:', pool.symbol);
+    
+    // Update URL to include pool identifier
+    const poolId = encodeURIComponent(pool.pool || `${pool.project}-${pool.symbol}-${pool.chain}`);
+    const params = new URLSearchParams(window.location.search);
+    params.set('pool', poolId);
+    const newUrl = `${window.location.pathname}?${params.toString()}`;
+    window.history.pushState({}, '', newUrl);
+    
+    // Update page title
+    document.title = `${pool.symbol} on ${pool.project} | DeFi Garden 🌱`;
+    
+    // Scroll to top
+    window.scrollTo(0, 0);
+  };
+
+  // Handle navigation back from pool detail view
+  const handleBackFromDetail = () => {
+    setCurrentView('search');
+    setDetailPool(null);
+    
+    // Remove pool parameter from URL
+    const params = new URLSearchParams(window.location.search);
+    params.delete('pool');
+    const newUrl = params.toString() ? `${window.location.pathname}?${params.toString()}` : window.location.pathname;
+    window.history.pushState({}, '', newUrl);
+    
+    // Restore previous title
+    if (chainMode && selectedChain && !selectedToken) {
+      document.title = `${selectedChain} DeFi Yields | DeFi Garden 🌱`;
+    } else if (selectedToken) {
+      document.title = `${selectedToken.toUpperCase()} Yields | DeFi Garden 🌱`;
+    } else {
+      document.title = 'DeFi Garden 🌱 | Discover Highest Yield Farming Opportunities Across All Chains';
+    }
   };
 
   // Handle yield calculator
@@ -1075,6 +1338,23 @@ function App() {
         return [...prev, poolType];
       }
     });
+  };
+
+  // Handle protocol selection (multi-select)
+  const handleProtocolToggle = (protocolFriendlyName) => {
+    setSelectedProtocols(prev => {
+      if (prev.includes(protocolFriendlyName)) {
+        return prev.filter(p => p !== protocolFriendlyName);
+      } else {
+        return [...prev, protocolFriendlyName];
+      }
+    });
+  };
+
+  // Handle popular protocols selection (replaces current selection)
+  const handlePopularProtocols = () => {
+    const popularProtocolNames = availableProtocols.popular.map(p => p.friendlyName);
+    setSelectedProtocols(popularProtocolNames);
   };
 
   // Handle TVL selection
@@ -1112,6 +1392,66 @@ function App() {
   };
 
   // Always render UI immediately - no blocking loading state
+
+  // Add debug logging for pool detail view state
+  console.log('App render - currentView:', currentView, 'detailPool:', detailPool ? detailPool.symbol : 'null');
+  
+  // Add a timer to check state after component should disappear
+  if (currentView === 'pool-detail' && detailPool) {
+    setTimeout(() => {
+      console.log('After 2 seconds - currentView:', currentView, 'detailPool:', detailPool ? detailPool.symbol : 'null');
+    }, 2000);
+  }
+
+  // Render Pool Detail View if active
+  if (currentView === 'pool-detail' && detailPool) {
+    console.log('Rendering pool detail view for:', detailPool.symbol);
+    return React.createElement('div', { className: 'app pool-detail-view' },
+      // Theme Toggle
+      React.createElement('button', {
+        className: 'theme-toggle',
+        'data-theme': isDarkMode ? 'dark' : 'light',
+        onClick: toggleTheme,
+        'aria-label': `Switch to ${isDarkMode ? 'light' : 'dark'} mode`
+      },
+        React.createElement('div', { className: 'theme-toggle-icon' },
+          isDarkMode ? '☀️' : '🌙'
+        ),
+        React.createElement('div', { className: 'theme-toggle-switch' },
+          React.createElement('div', { className: 'theme-toggle-handle' })
+        ),
+        React.createElement('div', { className: 'theme-toggle-text' },
+          isDarkMode ? 'Light' : 'Dark'
+        )
+      ),
+      
+      React.createElement('div', { className: 'container' },
+        React.createElement(PoolDetail, {
+          pool: detailPool,
+          onBack: handleBackFromDetail,
+          calculateYields: calculateYields,
+          formatCurrency: formatCurrency,
+          formatAPY: formatAPY,
+          getProtocolUrl: getProtocolUrl,
+          getProtocolUrlWithRef: getProtocolUrlWithRef,
+          isDarkMode: isDarkMode
+        })
+      ),
+      
+      // Footer
+      React.createElement('footer', { className: 'app-footer' },
+        React.createElement('p', null,
+          'Powered by ',
+          React.createElement('a', {
+            href: 'https://api-docs.defillama.com/',
+            target: '_blank',
+            rel: 'noopener noreferrer'
+          }, 'Defillama API'),
+          '. Made with AI & Degen Love.'
+        )
+      )
+    );
+  }
 
   return React.createElement('div', { 
     className: `app ${(selectedToken || (chainMode && selectedChain)) ? 'has-results' : ''}` 
@@ -1236,6 +1576,43 @@ function App() {
                       '--chain-color': getChainColor(chain)
                     }
                   }, chain)
+                )
+              )
+            )
+          ),
+
+          // Protocols Filter Row - only show when protocols are available
+          availableProtocols.all.length > 0 && React.createElement('div', { className: 'filter-section' },
+            React.createElement('div', { className: 'filter-section-header' },
+              React.createElement('label', { className: 'filter-label' }, 'Protocols')
+            ),
+            React.createElement('div', { className: 'filter-row' },
+              React.createElement('div', { className: 'filter-pills-container' },
+                // Popular button
+                availableProtocols.popular.length > 0 && React.createElement('button', {
+                  className: `filter-pill protocol-pill popular ${
+                    availableProtocols.popular.every(p => selectedProtocols.includes(p.friendlyName)) &&
+                    selectedProtocols.length === availableProtocols.popular.length ? 'active' : ''
+                  }`,
+                  onClick: handlePopularProtocols
+                }, 'Popular'),
+                
+                // All protocols button
+                React.createElement('button', {
+                  className: `filter-pill protocol-pill ${selectedProtocols.length === 0 ? 'active' : ''}`,
+                  onClick: () => setSelectedProtocols([])
+                }, 'All Protocols'),
+                
+                // Individual protocol pills (show top 10 to avoid overcrowding)
+                availableProtocols.all.slice(0, 10).map(protocol => 
+                  React.createElement('button', {
+                    key: protocol.friendlyName,
+                    className: `filter-pill protocol-pill ${selectedProtocols.includes(protocol.friendlyName) ? 'active' : ''}`,
+                    onClick: () => handleProtocolToggle(protocol.friendlyName)
+                  }, 
+                    protocol.friendlyName,
+                    React.createElement('span', { className: 'pill-count' }, `(${protocol.poolCount})`)
+                  )
                 )
               )
             )

--- a/index.html
+++ b/index.html
@@ -43,7 +43,9 @@
     
     <!-- Load CSS non-blocking -->
     <link rel="stylesheet" href="style.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="pool-detail-styles.css" media="print" onload="this.media='all'">
     <noscript><link rel="stylesheet" href="style.css"></noscript>
+    <noscript><link rel="stylesheet" href="pool-detail-styles.css"></noscript>
     
     <script>
         // Define process global before React loads to prevent ReferenceError
@@ -58,6 +60,7 @@
 <body>
     <div id="root"></div>
     
+    <script type="text/babel" src="PoolDetail.js"></script>
     <script type="text/babel" src="app.js"></script>
 </body>
 </html>

--- a/pool-detail-styles.css
+++ b/pool-detail-styles.css
@@ -1,0 +1,1004 @@
+/* Pool Detail Component Styles */
+.pool-detail-container {
+  min-height: 100vh;
+  background: var(--color-background);
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 40px 20px 20px 20px;
+}
+
+/* Header styling for pool detail */
+.pool-detail-container .header {
+  padding: 0 0 32px 0;
+  margin-bottom: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(16, 185, 129, 0.1);
+}
+
+.pool-detail-container .logo {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-black);
+  color: var(--color-text);
+  margin: 0;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.pool-detail-container .logo:hover {
+  color: var(--color-primary);
+  transform: translateY(-1px);
+}
+
+.pool-breadcrumb {
+  transition: all 0.2s ease;
+}
+
+.pool-breadcrumb:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--neuro-shadow-flat);
+}
+
+/* Ensure back button is visible */
+.back-to-results-btn {
+  display: flex !important;
+  align-items: center;
+  gap: var(--space-8);
+  z-index: 10;
+}
+
+.pool-detail-empty {
+  text-align: center;
+  padding: var(--space-32);
+  color: var(--color-text-secondary);
+}
+
+/* Back Navigation */
+.back-to-results-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  margin-bottom: var(--space-24);
+  padding: var(--space-12) var(--space-20);
+  background: var(--color-background);
+  border: none;
+  border-radius: 12px;
+  color: var(--color-text);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: var(--neuro-shadow-subtle);
+}
+
+.back-to-results-btn:hover {
+  box-shadow: var(--neuro-shadow-flat);
+  transform: translateY(-1px);
+  color: var(--color-primary);
+}
+
+/* Pool Info Section Enhancements */
+.pool-info-header:hover .pool-info-toggle {
+  box-shadow: var(--neuro-shadow-flat);
+  transform: translateY(-1px);
+}
+
+/* Explorer link styling */
+.pool-info-content a[href*="blockscan.com"]:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--neuro-shadow-flat);
+  background: var(--color-primary);
+  color: white;
+}
+
+.back-to-results-btn:active {
+  box-shadow: var(--neuro-shadow-pressed);
+  transform: translateY(0);
+}
+
+.back-arrow {
+  font-size: var(--font-size-lg);
+  font-weight: bold;
+}
+
+.back-button {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding: var(--space-12) var(--space-20);
+  border: none;
+  background: var(--color-background);
+  color: var(--color-text);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  box-shadow: var(--neuro-shadow-subtle);
+}
+
+.back-button:hover {
+  box-shadow: var(--neuro-shadow-flat);
+  transform: translateY(-1px);
+  color: var(--color-primary);
+}
+
+.back-button:active {
+  box-shadow: var(--neuro-shadow-pressed);
+  transform: translateY(0);
+}
+
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  flex: 1;
+}
+
+.breadcrumb-separator {
+  opacity: 0.5;
+}
+
+.breadcrumb-current {
+  color: var(--color-text);
+  font-weight: var(--font-weight-medium);
+}
+
+/* Pool Detail Header */
+.pool-detail-header {
+  background: var(--color-background);
+  border-radius: 24px;
+  padding: var(--space-32);
+  box-shadow: var(--neuro-shadow-raised);
+  margin-bottom: var(--space-32);
+}
+
+.pool-detail-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--space-24);
+}
+
+.pool-detail-info {
+  flex: 1;
+}
+
+.pool-symbol-large {
+  font-size: var(--font-size-4xl);
+  font-weight: var(--font-weight-black);
+  color: var(--color-text);
+  margin-bottom: var(--space-8);
+  font-family: monospace;
+  line-height: 1.2;
+}
+
+.pool-main-info {
+  flex: 1;
+}
+
+.pool-meta-info {
+  display: flex;
+  align-items: center;
+  gap: var(--space-12);
+  margin-bottom: var(--space-16);
+  color: var(--color-text-secondary);
+}
+
+.pool-project {
+  font-size: var(--font-size-lg);
+  color: var(--color-text);
+  font-weight: var(--font-weight-medium);
+}
+
+.pool-chain {
+  font-size: var(--font-size-base);
+  color: var(--color-primary);
+  font-weight: var(--font-weight-medium);
+}
+
+.separator {
+  opacity: 0.6;
+  font-weight: normal;
+}
+
+.protocol-name {
+  font-size: var(--font-size-lg);
+  color: var(--color-text);
+  font-weight: var(--font-weight-medium);
+}
+
+.protocol-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-4);
+  color: var(--color-primary);
+  text-decoration: none;
+  font-size: var(--font-size-sm);
+  padding: var(--space-4) var(--space-8);
+  background: var(--color-background);
+  border-radius: 8px;
+  box-shadow: var(--neuro-shadow-subtle);
+  transition: all 0.2s ease;
+}
+
+.protocol-link:hover {
+  box-shadow: var(--neuro-shadow-flat);
+  transform: translateY(-1px);
+}
+
+.pool-type-badge {
+  display: inline-flex;
+  align-items: center;
+  background: var(--color-background);
+  color: var(--color-primary);
+  padding: var(--space-6) var(--space-12);
+  border-radius: 16px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  box-shadow: var(--neuro-shadow-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.pool-detail-apy {
+  text-align: right;
+}
+
+.apy-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-4);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.apy-value-large {
+  font-size: var(--font-size-4xl);
+  font-weight: var(--font-weight-black);
+  color: var(--color-primary);
+  background: var(--color-background);
+  padding: var(--space-16) var(--space-24);
+  border-radius: 16px;
+  box-shadow: var(--neuro-shadow-pressed);
+  display: inline-block;
+}
+
+/* Pool Metrics Row */
+.pool-metrics-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-20);
+  margin-top: var(--space-24);
+}
+
+.metric-card {
+  background: var(--color-background);
+  border-radius: 16px;
+  padding: var(--space-20);
+  box-shadow: var(--neuro-shadow-subtle);
+  transition: all 0.3s ease;
+  text-align: center;
+}
+
+.metric-card:hover {
+  box-shadow: var(--neuro-shadow-flat);
+  transform: translateY(-2px);
+}
+
+.metric-card.highlight {
+  background: linear-gradient(135deg, var(--color-background), var(--color-forest-light));
+  box-shadow: var(--neuro-shadow-raised);
+}
+
+.apy-value {
+  color: var(--color-primary);
+  font-weight: var(--font-weight-black);
+}
+
+.apy-breakdown-toggle {
+  margin-top: var(--space-8);
+  padding: var(--space-4) var(--space-8);
+  background: var(--color-background);
+  border: none;
+  border-radius: 8px;
+  color: var(--color-primary);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: var(--neuro-shadow-subtle);
+}
+
+.apy-breakdown-toggle:hover {
+  box-shadow: var(--neuro-shadow-flat);
+}
+
+.metric-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-8);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: var(--font-weight-medium);
+}
+
+.metric-value {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+}
+
+.metric-subvalue {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-top: var(--space-4);
+}
+
+/* APY Breakdown Details */
+.apy-breakdown-details {
+  margin-top: var(--space-16);
+  padding: var(--space-16);
+  background: var(--color-background);
+  border-radius: 12px;
+  box-shadow: var(--neuro-shadow-pressed);
+}
+
+.breakdown-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-8) 0;
+}
+
+.breakdown-item:not(:last-child) {
+  border-bottom: 1px solid rgba(16, 185, 129, 0.1);
+}
+
+.breakdown-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.breakdown-value {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+}
+
+/* Yield Calculator Section */
+.yield-calculator-section {
+  background: var(--color-background);
+  border-radius: 24px;
+  padding: var(--space-32);
+  box-shadow: var(--neuro-shadow-raised);
+  margin-top: var(--space-32);
+}
+
+.section-title {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+  margin-bottom: var(--space-24);
+  text-align: center;
+}
+
+.calculator-card {
+  background: var(--color-background);
+  border-radius: 16px;
+  padding: var(--space-24);
+  box-shadow: var(--neuro-shadow-subtle);
+}
+
+.investment-input-group {
+  margin-bottom: var(--space-32);
+  text-align: center;
+}
+
+.input-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-8);
+  margin: var(--space-16) 0;
+}
+
+.currency-symbol {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-secondary);
+}
+
+.amount-input {
+  width: 200px;
+  padding: var(--space-12) var(--space-16);
+  border: none;
+  border-radius: 12px;
+  background: var(--color-background);
+  color: var(--color-text);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-medium);
+  text-align: center;
+  box-shadow: var(--neuro-shadow-pressed);
+  outline: none;
+  transition: all 0.2s ease;
+}
+
+.amount-input:focus {
+  box-shadow: var(--neuro-shadow-pressed), 0 0 0 3px rgba(16, 185, 129, 0.2);
+}
+
+.quick-amounts {
+  display: flex;
+  gap: var(--space-12);
+  justify-content: center;
+  margin-top: var(--space-16);
+}
+
+.quick-amount-btn {
+  padding: var(--space-8) var(--space-16);
+  border: none;
+  background: var(--color-background);
+  color: var(--color-text-secondary);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  box-shadow: var(--neuro-shadow-subtle);
+}
+
+.quick-amount-btn:hover {
+  box-shadow: var(--neuro-shadow-flat);
+  transform: translateY(-1px);
+}
+
+.quick-amount-btn.active {
+  background: var(--color-primary);
+  color: white;
+  box-shadow: var(--neuro-shadow-pressed);
+}
+
+.input-label {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  margin-bottom: var(--space-8);
+  display: block;
+}
+
+
+/* Yield Results Grid */
+.yield-results-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-16);
+  margin-bottom: var(--space-24);
+}
+
+.yield-result-card {
+  background: var(--color-background);
+  border-radius: 12px;
+  padding: var(--space-16);
+  text-align: center;
+  box-shadow: var(--neuro-shadow-subtle);
+  transition: all 0.2s ease;
+}
+
+.yield-result-card:hover {
+  box-shadow: var(--neuro-shadow-flat);
+  transform: translateY(-1px);
+}
+
+.yield-period {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  font-weight: var(--font-weight-medium);
+  margin-bottom: var(--space-4);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.yield-amount {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  margin-bottom: var(--space-4);
+}
+
+.yield-rate {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.yield-disclaimer {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  text-align: center;
+  font-style: italic;
+  padding: var(--space-16);
+  background: rgba(16, 185, 129, 0.05);
+  border-radius: 8px;
+  border-left: 3px solid var(--color-primary);
+}
+
+/* Call to Action Section */
+.cta-section {
+  text-align: center;
+  margin-top: var(--space-24);
+}
+
+.start-earning-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding: var(--space-16) var(--space-32);
+  background: var(--color-primary);
+  color: white;
+  border: none;
+  border-radius: 16px;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: var(--neuro-shadow-raised);
+  text-decoration: none;
+}
+
+.start-earning-btn:hover {
+  background: var(--color-forest);
+  box-shadow: var(--neuro-shadow-raised), 0 8px 25px rgba(16, 185, 129, 0.3);
+  transform: translateY(-2px);
+}
+
+.start-earning-btn:active {
+  box-shadow: var(--neuro-shadow-flat);
+  transform: translateY(0);
+}
+
+.start-earning-btn.primary {
+  background: var(--color-primary);
+}
+
+.arrow {
+  font-weight: bold;
+  transition: transform 0.2s ease;
+}
+
+.start-earning-btn:hover .arrow {
+  transform: translateX(2px);
+}
+
+/* Additional Information Section */
+.additional-info-section {
+  background: var(--color-background);
+  border-radius: 24px;
+  padding: var(--space-32);
+  box-shadow: var(--neuro-shadow-raised);
+  margin-top: var(--space-32);
+}
+
+.section-subtitle {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+  margin-bottom: var(--space-20);
+  text-align: center;
+}
+
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--space-20);
+}
+
+.info-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  padding: var(--space-16);
+  background: var(--color-background);
+  border-radius: 12px;
+  box-shadow: var(--neuro-shadow-subtle);
+}
+
+.info-item.full-width {
+  grid-column: 1 / -1;
+}
+
+.info-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  font-weight: var(--font-weight-medium);
+}
+
+.info-value {
+  font-size: var(--font-size-base);
+  color: var(--color-text);
+  font-weight: var(--font-weight-semibold);
+  word-break: break-all;
+}
+
+.tokens-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-8);
+  margin-top: var(--space-4);
+}
+
+.token-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-4) var(--space-8);
+  background: var(--color-background);
+  color: var(--color-text);
+  border-radius: 8px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  box-shadow: var(--neuro-shadow-subtle);
+}
+
+.token-badge.reward {
+  background: var(--color-primary);
+  color: white;
+}
+
+/* Risk Indicators */
+/* Risk Disclaimer */
+.risk-disclaimer {
+  background: rgba(255, 193, 7, 0.1);
+  border: 1px solid rgba(255, 193, 7, 0.3);
+  border-radius: 12px;
+  padding: var(--space-20);
+  margin-top: var(--space-32);
+}
+
+.disclaimer-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: #ff6b35;
+  margin-bottom: var(--space-12);
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+}
+
+.risk-disclaimer p {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+  .pool-detail-container {
+    padding: 20px 16px 16px 16px;
+  }
+  
+  .pool-detail-container .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-16);
+    padding-bottom: 24px;
+    margin-bottom: 24px;
+  }
+  
+  .pool-breadcrumb {
+    align-self: stretch;
+    justify-content: center;
+  }
+  
+  .pool-hero-card {
+    margin-bottom: 24px;
+  }
+  
+  .quick-metrics {
+    margin-bottom: 24px;
+  }
+  
+  .pool-detail-header {
+    padding: var(--space-20);
+  }
+  
+  .pool-metrics-row {
+    grid-template-columns: 1fr;
+  }
+  
+  .yield-results-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .quick-amounts {
+    flex-wrap: wrap;
+  }
+  
+  .amount-input {
+    width: 150px;
+  }
+  
+  .yield-calculator-section,
+  .additional-info-section {
+    padding: var(--space-20);
+  }
+}
+
+/* Enhanced Neumorphic Hero Section */
+.pool-hero-card {
+  position: relative;
+  transition: all 0.3s ease;
+}
+
+.pool-hero-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--neuro-shadow-raised), 0 12px 35px rgba(16, 185, 129, 0.1);
+}
+
+.pool-symbol-hero {
+  background: linear-gradient(135deg, var(--color-text) 0%, var(--color-primary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.apy-display-hero {
+  transition: all 0.3s ease;
+}
+
+.apy-display-hero:hover {
+  box-shadow: var(--neuro-shadow-flat);
+  transform: translateY(-1px);
+}
+
+/* Enhanced CTA Button */
+.cta-button-primary {
+  position: relative;
+  overflow: hidden;
+  transition: all 0.3s ease;
+}
+
+.cta-button-primary::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.2);
+  transform: translate(-50%, -50%);
+  transition: width 0.6s, height 0.6s;
+}
+
+.cta-button-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--neuro-shadow-raised), 0 8px 25px rgba(16, 185, 129, 0.3);
+}
+
+.cta-button-primary:hover::before {
+  width: 300px;
+  height: 300px;
+}
+
+.cta-button-primary:hover .arrow {
+  transform: translateX(2px);
+}
+
+.cta-button-primary:active {
+  transform: translateY(0);
+  box-shadow: var(--neuro-shadow-flat);
+}
+
+/* Quick Metrics Cards */
+.metric-card-simple {
+  cursor: default;
+  transition: all 0.3s ease;
+}
+
+.metric-card-simple:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--neuro-shadow-flat);
+}
+
+.risk-card {
+  position: relative;
+}
+
+.risk-card::after {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: -1px;
+  right: -1px;
+  bottom: -1px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, transparent 0%, rgba(16, 185, 129, 0.1) 100%);
+  z-index: -1;
+}
+
+/* Calculator Enhancements */
+.calculator-compact {
+  transition: all 0.3s ease;
+}
+
+.calculator-compact.expanded {
+  transform: translateY(-2px);
+}
+
+.calculator-header:hover .calculator-toggle {
+  box-shadow: var(--neuro-shadow-flat);
+  transform: translateY(-1px);
+}
+
+.quick-amount-btn {
+  transition: all 0.2s ease;
+}
+
+.quick-amount-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--neuro-shadow-flat);
+}
+
+.quick-amount-btn:active {
+  transform: translateY(0);
+  box-shadow: var(--neuro-shadow-pressed);
+}
+
+/* Pool Essentials Section */
+.pool-essentials h3 {
+  background: linear-gradient(135deg, var(--color-text) 0%, var(--color-primary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Trust Indicators */
+.trust-badge {
+  transition: all 0.2s ease;
+}
+
+.trust-badge:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--neuro-shadow-flat);
+}
+
+/* Mobile-First Responsive Design */
+@media (max-width: 768px) {
+  .pool-hero-content {
+    flex-direction: column !important;
+    gap: 20px !important;
+  }
+  
+  .apy-cta-section {
+    align-items: stretch !important;
+    text-align: center !important;
+  }
+  
+  .pool-symbol-hero {
+    font-size: var(--font-size-3xl) !important;
+    text-align: center;
+  }
+  
+  .apy-display-hero {
+    min-width: auto !important;
+    align-self: center;
+  }
+  
+  .cta-button-primary {
+    width: 100%;
+    justify-content: center;
+  }
+  
+  .quick-metrics {
+    grid-template-columns: 1fr !important;
+  }
+  
+  .calculator-compact {
+    padding: 16px !important;
+  }
+  
+  .calculator-compact.expanded {
+    padding: 20px !important;
+  }
+}
+
+/* Animation Support */
+.animate-on-mount {
+  animation: fadeInUp 0.5s ease-out;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  .pool-hero-card,
+  .metric-card-simple,
+  .calculator-compact,
+  .pool-essentials {
+    box-shadow: 0 0 0 2px var(--color-text) !important;
+  }
+  
+  .cta-button-primary {
+    box-shadow: 0 0 0 2px var(--color-primary) !important;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  
+  .pool-hero-card:hover,
+  .metric-card-simple:hover,
+  .cta-button-primary:hover {
+    transform: none !important;
+  }
+}
+
+/* Pool Detail View Override for App */
+.app.pool-detail-view {
+  padding: 0;
+}
+
+.app.pool-detail-view .container {
+  max-width: none;
+  padding: 0;
+}
+
+/* Focus states for accessibility */
+.focusable-element:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  box-shadow: var(--neuro-shadow-raised), 0 0 0 4px rgba(16, 185, 129, 0.2);
+}
+
+.cta-button-primary:focus-visible {
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
+
+/* Loading states */
+.loading-shimmer {
+  background: linear-gradient(90deg, 
+    var(--color-background) 25%, 
+    rgba(16, 185, 129, 0.1) 50%, 
+    var(--color-background) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 2s infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}

--- a/test_protocol_parsing.js
+++ b/test_protocol_parsing.js
@@ -1,0 +1,114 @@
+// Simple test for protocol parsing functionality
+// This is a standalone test file to verify the protocol parsing logic
+
+// Mock the getFriendlyProtocolName function for testing
+const getFriendlyProtocolName = (protocolName) => {
+  if (!protocolName) return protocolName;
+  
+  const protocolNameMap = {
+    'aave-v2': 'Aave',
+    'aave-v3': 'Aave',
+    'aave': 'Aave',
+    'compound-v2': 'Compound',
+    'compound-v3': 'Compound', 
+    'compound': 'Compound',
+    'uniswap-v2': 'Uniswap',
+    'uniswap-v3': 'Uniswap',
+    'uniswap': 'Uniswap',
+  };
+  return protocolNameMap[protocolName.toLowerCase()] || 
+         protocolName.charAt(0).toUpperCase() + protocolName.slice(1).replace(/-/g, ' ');
+};
+
+// Copy the parseNaturalLanguageQuery function for testing
+const parseNaturalLanguageQuery = (query, allTokens = [], allChains = [], allProtocols = []) => {
+  const lowerQuery = query.toLowerCase();
+  let token = '';
+  let chain = '';
+  let poolTypes = [];
+  let protocols = [];
+
+  // Simplified protocol parsing for testing
+  const protocolAliases = {
+    'aave': ['aave', 'aave-v2', 'aave-v3'],
+    'compound': ['compound', 'compound-v2', 'compound-v3', 'comp'],
+    'uniswap': ['uniswap', 'uniswap-v2', 'uniswap-v3', 'uni'],
+    'curve': ['curve', 'curve-dex', 'crv'],
+    'euler': ['euler'],
+    'venus': ['venus'],
+  };
+
+  const protocolKeywords = ['on', 'via', 'using', 'through', 'from', 'with', 'in'];
+  
+  // Method 1: Look for protocols after context keywords
+  const words = lowerQuery.split(/\s+/);
+  for (let i = 0; i < words.length - 1; i++) {
+    if (protocolKeywords.includes(words[i])) {
+      const protocolCandidate = words[i + 1];
+      
+      for (const [friendlyName, aliases] of Object.entries(protocolAliases)) {
+        if (aliases.some(alias => alias === protocolCandidate || protocolCandidate.includes(alias))) {
+          protocols.push(friendlyName);
+          break;
+        }
+      }
+    }
+  }
+  
+  // Method 2: Direct protocol name detection (fallback)
+  if (protocols.length === 0) {
+    for (const [friendlyName, aliases] of Object.entries(protocolAliases)) {
+      if (aliases.some(alias => lowerQuery.includes(alias))) {
+        const aliasMatch = aliases.find(alias => lowerQuery.includes(alias));
+        const wordBoundaryRegex = new RegExp(`\\b${aliasMatch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i');
+        
+        if (wordBoundaryRegex.test(lowerQuery)) {
+          protocols.push(friendlyName);
+        }
+      }
+    }
+  }
+  
+  // Method 3: Protocol-first detection (e.g., "aave on arbitrum")
+  if (protocols.length === 0) {
+    const firstWord = words[0];
+    if (firstWord) {
+      for (const [friendlyName, aliases] of Object.entries(protocolAliases)) {
+        if (aliases.includes(firstWord)) {
+          protocols.push(friendlyName);
+          break;
+        }
+      }
+    }
+  }
+  
+  // Parse token (simplified)
+  const tokens = ['USDC', 'USDT', 'ETH', 'BTC'];
+  for (const t of tokens) {
+    if (lowerQuery.includes(t.toLowerCase())) {
+      token = t;
+      break;
+    }
+  }
+  
+  return { token, chain, poolTypes, protocols };
+};
+
+// Test cases
+const testCases = [
+  'usdc on aave',
+  'eth on euler on base',
+  'usdt lending on venus',
+  'aave on arbitrum', 
+  'compound yields',
+  'usdc on compound'
+];
+
+console.log('Testing Protocol-Aware Natural Language Parsing:');
+console.log('='.repeat(50));
+
+testCases.forEach((testCase, index) => {
+  console.log(`\nTest ${index + 1}: "${testCase}"`);
+  const result = parseNaturalLanguageQuery(testCase, ['USDC', 'USDT', 'ETH'], ['Base', 'Arbitrum'], []);
+  console.log('Result:', JSON.stringify(result, null, 2));
+});

--- a/test_qualifier_fix.js
+++ b/test_qualifier_fix.js
@@ -1,0 +1,125 @@
+// Test the qualifier word fix
+const parseNaturalLanguageQuery = (query, allTokens = [], allChains = [], allProtocols = []) => {
+  const lowerQuery = query.toLowerCase();
+  let token = '';
+  let chain = '';
+  let poolTypes = [];
+  let protocols = [];
+
+  // --- Parse Token ---
+  if (allTokens && allTokens.length > 0) {
+    const exactTokenMatch = allTokens.find(t => t.toLowerCase() === lowerQuery);
+    if (exactTokenMatch) {
+        token = exactTokenMatch;
+    } else {
+        // Split query into words for context analysis
+        const words = lowerQuery.split(/\s+/);
+        
+        // Filter out qualifier words that aren't tokens
+        const qualifierWords = ['best', 'highest', 'top', 'good', 'great', 'yields', 'yield', 'farming', 'opportunities', 'rates', 'apy'];
+        const filteredWords = words.filter(word => !qualifierWords.includes(word));
+        
+        console.log('Original words:', words);
+        console.log('Filtered words:', filteredWords);
+        
+        // Find chain context indicators to exclude words after them
+        const chainIndicators = ['on', 'chain', 'network', 'blockchain'];
+        let tokenCandidateWords = [];
+        
+        for (let i = 0; i < filteredWords.length; i++) {
+            if (chainIndicators.includes(filteredWords[i])) {
+                // Stop including words after chain indicators
+                tokenCandidateWords = filteredWords.slice(0, i);
+                break;
+            }
+        }
+        
+        // If no chain indicators found, use first few filtered words (typically tokens come first)
+        if (tokenCandidateWords.length === 0) {
+            tokenCandidateWords = filteredWords.slice(0, Math.min(3, filteredWords.length));
+        }
+        
+        const tokenCandidateText = tokenCandidateWords.join(' ');
+        console.log('Token candidate text:', tokenCandidateText);
+    }
+  }
+
+  // --- Parse Chain ---
+  const chainAliases = {
+      'base': 'Base',
+      'ethereum': 'Ethereum',
+      'arbitrum': 'Arbitrum',
+      'solana': 'Solana'
+  };
+
+  if (allChains && allChains.length > 0) {
+    for (const alias in chainAliases) {
+        if (lowerQuery.includes(alias)) {
+            const matchedChain = chainAliases[alias];
+            if (allChains.includes(matchedChain)) {
+                chain = matchedChain;
+                break;
+            }
+        }
+    }
+  }
+
+  // --- Parse Protocols ---
+  const protocolAliases = {
+    'aave': ['aave', 'aave-v2', 'aave-v3'],
+    'compound': ['compound', 'compound-v2', 'compound-v3'],
+    'curve': ['curve', 'curve-dex']
+  };
+
+  const protocolKeywords = ['on', 'via', 'using', 'through', 'from', 'with', 'in'];
+  
+  // Method 1: Look for protocols after context keywords
+  const words = lowerQuery.split(/\s+/);
+  const qualifierWords = ['best', 'highest', 'top', 'good', 'great', 'yields', 'yield', 'farming', 'opportunities', 'rates', 'apy'];
+  const filteredWords = words.filter(word => !qualifierWords.includes(word));
+  
+  for (let i = 0; i < filteredWords.length - 1; i++) {
+    if (protocolKeywords.includes(filteredWords[i])) {
+      const protocolCandidate = filteredWords[i + 1];
+      
+      for (const [friendlyName, aliases] of Object.entries(protocolAliases)) {
+        if (aliases.some(alias => alias === protocolCandidate || protocolCandidate.includes(alias))) {
+          protocols.push(friendlyName);
+          break;
+        }
+      }
+    }
+  }
+
+  // Pool types
+  if (lowerQuery.includes('lending')) {
+      poolTypes.push('Lending');
+  }
+  if (lowerQuery.includes('yield') || lowerQuery.includes('farming')) {
+      poolTypes.push('Yield Farming');
+  }
+
+  return { token, chain, poolTypes, protocols };
+};
+
+// Test cases
+console.log('=== Testing Qualifier Word Fix ===\n');
+
+const testCases = [
+  'best yields on base',
+  'best yields on aave', 
+  'best yields on curve',
+  'highest yields on solana',
+  'highest apy on ethereum',
+  'top usdc yields'
+];
+
+const mockTokens = ['USDC', 'ETH', 'SOL', 'SOLANA']; // Added SOL/SOLANA to test disambiguation
+const mockChains = ['Base', 'Ethereum', 'Solana'];
+
+testCases.forEach((testCase, index) => {
+  console.log(`Test ${index + 1}: "${testCase}"`);
+  const result = parseNaturalLanguageQuery(testCase, mockTokens, mockChains, []);
+  console.log('Result:', JSON.stringify(result, null, 2));
+  console.log('---\n');
+});


### PR DESCRIPTION
- Add protocol filter that dynamically shows protocols based on selected chain/token
- Position protocol filter between chain and pool type filters for better UX
- Group protocol variants (aave-v2, aave-v3) under friendly names (Aave)
- Include Popular and All Protocols quick filter options
- Show protocol pool counts in filter pills
- Support multi-select protocol filtering with URL persistence
- Improve protocol discovery by chain (e.g., Aerodrome on Base, Raydium on Solana)