### PR TITLE
fix: make Calculate Yield button navigate to pool details page

### DIFF
--- a/app.js
+++ b/app.js
@@ -1508,12 +1508,15 @@ function App() {
     }
   };
 
-  // Handle yield calculator
+  // Handle yield calculator - navigate to pool details page
   const handleCalculateYield = (pool, e) => {
     e.preventDefault();
     e.stopPropagation();
-    setSelectedPool(pool);
-    setShowYieldCalculator(true);
+    console.log('handleCalculateYield called for:', pool.symbol);
+    // Set the pool for detail view (same logic as handlePoolClick)
+    setDetailPool(pool);
+    setCurrentView('pool-detail');
+    console.log('Set currentView to pool-detail, detailPool to:', pool.symbol);
   };
 
   // Handle pool type selection (multi-select)


### PR DESCRIPTION
Previously clicking 'Calculate Yield' in search results showed an old yield calculator alert. Now it properly navigates to the pool details page where users can use the enhanced calculator.