### PR TITLE
fix: OAuth Protected Resource Metadata compliance and auth.md backtick parsing bug

### DIFF
--- a/.well-known/oauth-protected-resource.json
+++ b/.well-known/oauth-protected-resource.json
@@ -6,5 +6,8 @@
   "scopes_supported": [
     "read",
     "write"
+  ],
+  "bearer_methods_supported": [
+    "header"
   ]
 }

--- a/auth.md
+++ b/auth.md
@@ -3,8 +3,8 @@
 Welcome, AI Agent! DeFi Garden supports automated registration and authentication for autonomous AI agents.
 
 ## Discovery Endpoints
-- **OAuth 2.0 Authorization Server Metadata:** `https://www.defi.garden/.well-known/oauth-authorization-server`
-- **OAuth Protected Resource Metadata:** `https://www.defi.garden/.well-known/oauth-protected-resource`
+- **OAuth 2.0 Authorization Server Metadata:** https://www.defi.garden/.well-known/oauth-authorization-server
+- **OAuth Protected Resource Metadata:** https://www.defi.garden/.well-known/oauth-protected-resource
 
 ## Authentication Flows
 
@@ -13,16 +13,16 @@ We support two distinct flows for agents to authenticate:
 ### 1. Anonymous Registration Flow
 Ideal for read-only crawlers or agents performing basic searches on behalf of users.
 - Register to obtain an API key by making a POST request to:
-  `https://www.defi.garden/api/agent/identity`
+  https://www.defi.garden/api/agent/identity
 - Exchange the registration for a claim:
-  `https://www.defi.garden/api/agent/identity/claim`
+  https://www.defi.garden/api/agent/identity/claim
 
 ### 2. Identity Assertion Flow (ID-JAG)
 For personalized, user-delegated sessions where the agent acts under a user-verifiable cryptographic identity.
 - We support the standard **ID-JAG** (IDentification by JSON Web Token with Agent Guarantees) assertion format.
 - Present your ID-JAG token to:
-  `https://www.defi.garden/api/agent/identity`
+  https://www.defi.garden/api/agent/identity
 - Revoke credentials using the revocation endpoint:
-  `https://www.defi.garden/api/oauth2/revoke`
+  https://www.defi.garden/api/oauth2/revoke
 
 For human developers, see our repository and documentation at https://github.com/alex0xhodler/defi_garden.


### PR DESCRIPTION
Adds the required 'bearer_methods_supported': ['header'] parameter inside the OAuth Protected Resource Metadata JSON. Additionally, removes backticks around discovery URLs inside '/auth.md' to prevent agentic parser backtick-scraping bugs (which appended trailing '%60' to URLs causing 404s on scan runs).