### PR TITLE
feat(016): re-brand empty-state buttons to neumorphic tokens

### DIFF
--- a/style.css
+++ b/style.css
@@ -2442,7 +2442,7 @@ body {
   background: rgba(59, 130, 246, 0.1);
 }
 
-/* Reset Filters Button - styled like "I'm Feeling Degen" */
+/* Reset Filters Button - neumorphic recovery action (empty state) */
 .reset-filters-btn {
   margin-top: var(--space-20);
   display: inline-flex;
@@ -2450,26 +2450,30 @@ body {
   gap: var(--space-8);
   padding: var(--space-16) var(--space-24);
   border: none;
-  background: linear-gradient(135deg, var(--color-primary), var(--color-teal-600));
-  color: white;
-  border-radius: var(--neuro-radius-lg);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-radius: var(--neuro-radius-md);
   cursor: pointer;
   transition: all 0.3s ease;
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
-  box-shadow: var(--neuro-shadow-raised), 0 4px 15px rgba(33, 128, 141, 0.3);
+  box-shadow: var(--neuro-shadow-raised);
   min-width: auto;
 }
 
 .reset-filters-btn:hover {
-  background: linear-gradient(135deg, var(--color-teal-600), var(--color-teal-700));
-  box-shadow: var(--neuro-shadow-raised), 0 8px 25px rgba(33, 128, 141, 0.4);
-  transform: translateY(-3px);
+  box-shadow: var(--neuro-shadow-flat);
+  transform: translateY(-2px);
 }
 
 .reset-filters-btn:active {
-  box-shadow: var(--neuro-shadow-flat);
-  transform: translateY(0);
+  box-shadow: var(--neuro-shadow-pressed);
+  transform: translateY(1px);
+}
+
+.reset-filters-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 /* Responsive Design - Mobile Only (Desktop Unchanged) */


### PR DESCRIPTION
Ships backlog item 016 per `product-loop-kit/specs/016.md`, extracted cleanly from conflict-blocked #96.

- `.reset-filters-btn` re-tokened in place: `var(--color-surface)` background, `var(--color-text)` text, `var(--neuro-radius-md)`, `var(--neuro-shadow-raised)`
- Press physics: `:active` → pressed shadow + `translateY(1px)`; `:hover` → flat shadow + `translateY(-2px)`; `:focus-visible` → focus ring
- Zero gradients, zero rgba, layout properties unchanged; CSS-only diff (1 file, +14/−10)

Tests green: `test_planner.js`, `test_protocol_parsing.js`, `test_qualifier_fix.js`, `test_canonical.js` all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_