### PR TITLE
018: NL search actually works — root-cause fixes on live rendered UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -262,8 +262,13 @@ const parseNaturalLanguageQuery = (query, allTokens = [], allChains = [], allPro
   };
 
   if (allChains && allChains.length > 0) {
+    const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    // Short common aliases first (eth, arb, sol, op, ...) — word-boundary
+    // matched so a substring like "op" can't misfire inside "top yields".
     for (const alias in chainAliases) {
-      if (lowerQuery.includes(alias)) {
+      const aliasRegex = new RegExp(`\\b${escapeRegex(alias)}\\b`, 'i');
+      if (aliasRegex.test(lowerQuery)) {
         const matchedChain = chainAliases[alias];
         if (allChains.includes(matchedChain)) { // Ensure it's a valid, available chain
           chain = matchedChain;
@@ -271,10 +276,26 @@ const parseNaturalLanguageQuery = (query, allTokens = [], allChains = [], allPro
         }
       }
     }
+
+    // Fall back to matching any live chain name directly. chainAliases only
+    // covers ~25 common chains; allChains carries every chain actually
+    // present in the pool data (e.g. newer chains like Plasma), so a query
+    // naming one of those verbatim should still resolve.
+    if (!chain) {
+      for (const c of allChains) {
+        const chainRegex = new RegExp(`\\b${escapeRegex(c.toLowerCase())}\\b`, 'i');
+        if (chainRegex.test(lowerQuery)) {
+          chain = c;
+          break;
+        }
+      }
+    }
   }
 
   // --- Parse Pool Types ---
-  if (lowerQuery.includes('lending')) {
+  // Word-boundary stem match: catches "lending", "lend", "lender(s)" (e.g.
+  // "kamino lenders") without a per-string special case.
+  if (/\blend(ing|ers?)?\b/.test(lowerQuery)) {
     poolTypes.push('Lending');
   }
   if (lowerQuery.includes('lp') || lowerQuery.includes('dex')) {
@@ -386,23 +407,26 @@ const parseNaturalLanguageQuery = (query, allTokens = [], allChains = [], allPro
     }
   }
 
-  // Method 2: Direct protocol name detection (fallback) 
+  // Method 2: Direct protocol name detection (fallback)
   if (protocols.length === 0) {
     for (const [friendlyName, aliases] of Object.entries(protocolAliases)) {
-      if (aliases.some(alias => lowerQuery.includes(alias))) {
-        // Additional check: avoid matching common words that might be part of other contexts
-        const aliasMatch = aliases.find(alias => lowerQuery.includes(alias));
-
+      const aliasMatch = aliases.find(alias => {
         // Skip if the alias is likely a chain name
-        if (chainNames.includes(aliasMatch)) {
-          continue;
-        }
+        if (chainNames.includes(alias)) return false;
 
-        const wordBoundaryRegex = new RegExp(`\\b${aliasMatch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i');
+        // Forward: the alias appears in the query. Plain substring (no
+        // trailing word-boundary) on purpose — live friendly names derived
+        // from a slug can be word-fragments (e.g. "kamino-lend" ->
+        // "Kamino lend"), so "kamino lending" must still match "kamino lend".
+        if (lowerQuery.includes(alias)) return true;
 
-        if (wordBoundaryRegex.test(lowerQuery)) {
-          protocols.push(friendlyName);
-        }
+        // Reverse: a bare protocol word ("kamino") is one of the words
+        // making up a longer multi-word friendly name ("kamino lend").
+        return alias.split(/\s+/).includes(lowerQuery);
+      });
+
+      if (aliasMatch) {
+        protocols.push(friendlyName);
       }
     }
   }
@@ -1428,6 +1452,14 @@ function App() {
           }
         }
       }
+      // No filter active yet (e.g. before the very first NL search): compute
+      // across every pool. Without this branch, parseNaturalLanguageQuery's
+      // live protocol context is always empty pre-search — the parser then
+      // silently falls back to its ~26-entry static protocol list, so any
+      // live protocol outside that list (e.g. Kamino) can never match.
+      else if (!selectedToken && !(chainMode && selectedChain)) {
+        includePool = true;
+      }
 
       if (includePool) {
         // Get friendly name and group protocols with same friendly name
@@ -1850,15 +1882,23 @@ function App() {
 
           // Apply filters based on natural language parsing
           // Prioritize natural language over current state if found
+
+          // A protocol/pool-type query with no token or chain ("convex",
+          // "kamino lending", "morpho lending") still needs a display mode
+          // to render results in — default it into the existing "All
+          // chains" mode so it reuses that mode's filtering/render path
+          // instead of resolving to an empty screen.
+          const effectiveChain = chain || ((!token && (protocols.length > 0 || poolTypes.length > 0)) ? 'All' : '');
+
           if (token) setSelectedToken(token);
-          if (chain) setSelectedChain(chain);
+          if (effectiveChain) setSelectedChain(effectiveChain);
           if (poolTypes.length > 0) setSelectedPoolTypes(poolTypes);
           if (protocols.length > 0) setSelectedProtocols(protocols.map(normalizeProtocolName));
 
           // Set chain mode if chain is detected and no token is specified, or if chain is dominant
           // If token is found, it's token-first mode.
           // If chain is found and no token, it's chain-first mode.
-          if (chain && !token) {
+          if (effectiveChain && !token) {
             setChainMode(true);
             setMinTvl(DEFAULT_MIN_TVL);
           } else {

--- a/app.js
+++ b/app.js
@@ -1923,6 +1923,23 @@ function App() {
           setShowAutocomplete(false);
           setHighlightedIndex(-1);
 
+          // search_success / search_abandonment (spec 018's own measurement
+          // plan) — this Enter-triggered NL parse is the code path all of
+          // this change's fixes live in, so it needs to be the thing that's
+          // actually measured, not just the pre-existing autocomplete/chip
+          // selection paths already wired below in handleChainSelect /
+          // handleTokenSelect.
+          if (token || effectiveChain || protocols.length > 0) {
+            Analytics.trackSearch(query, {
+              selected_token: token || undefined,
+              selected_chain: effectiveChain || undefined,
+              input_method: 'nl_search',
+              language
+            });
+          } else {
+            Analytics.trackSearchAbandonment(query, 0, { resultsCount: 0, language });
+          }
+
           // Update URL immediately after parsing and setting state
           // The useEffect that listens to state changes will then push the URL
         }

--- a/app.js
+++ b/app.js
@@ -409,16 +409,30 @@ const parseNaturalLanguageQuery = (query, allTokens = [], allChains = [], allPro
 
   // Method 2: Direct protocol name detection (fallback)
   if (protocols.length === 0) {
+    const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
     for (const [friendlyName, aliases] of Object.entries(protocolAliases)) {
       const aliasMatch = aliases.find(alias => {
         // Skip if the alias is likely a chain name
         if (chainNames.includes(alias)) return false;
 
-        // Forward: the alias appears in the query. Plain substring (no
-        // trailing word-boundary) on purpose — live friendly names derived
-        // from a slug can be word-fragments (e.g. "kamino-lend" ->
-        // "Kamino lend"), so "kamino lending" must still match "kamino lend".
-        if (lowerQuery.includes(alias)) return true;
+        const isMultiWord = /\s/.test(alias);
+
+        // Forward: the alias appears in the query. Single-word aliases are
+        // matched with a strict, both-ends word boundary — short static
+        // fallback abbreviations ("comp", "bal", "joe") would otherwise
+        // false-match substrings of unrelated words ("compare", "global",
+        // "joel"). Multi-word aliases only need a LEADING boundary: live
+        // friendly names derived from a slug can end in a word-fragment
+        // (e.g. "kamino-lend" -> "Kamino lend"), so "kamino lending" must
+        // still match the "kamino lend" prefix — the fragment only occurs
+        // in a phrase's last word, and the earlier word(s) already carry
+        // enough specificity to keep this safe.
+        const forwardRegex = new RegExp(
+          isMultiWord ? `\\b${escapeRegex(alias)}` : `\\b${escapeRegex(alias)}\\b`,
+          'i'
+        );
+        if (forwardRegex.test(lowerQuery)) return true;
 
         // Reverse: a bare protocol word ("kamino") is one of the words
         // making up a longer multi-word friendly name ("kamino lend").

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,23 @@
         "fast-xml-parser": "^4.4.1"
       },
       "devDependencies": {
-        "playwright": "^1.61.1"
+        "@babel/standalone": "^8.0.4",
+        "playwright": "^1.61.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       },
       "engines": {
         "node": "22.x"
+      }
+    },
+    "node_modules/@babel/standalone": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-8.0.4.tgz",
+      "integrity": "sha512-z8WgyJCfEl7qGAfJJksICOL5zQPpfwa6Yew+91Txf1k3xuDtlDdDe5GX2QdIhgx0HD7oYOCLoF8Y6CwNdawJwQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -51,6 +64,26 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
@@ -81,6 +114,43 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/strnum": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "serve": "npx --yes http-server -p 8000 -c-1",
     "dev": "npx --yes http-server -p 8000 -c-1",
     "generate:llms": "node generate-llms.js",
-    "test": "node test_planner.js && node test_protocol_parsing.js && node test_qualifier_fix.js && node test_smoke.js && node test_canonical.js"
+    "test": "node test_planner.js && node test_protocol_parsing.js && node test_qualifier_fix.js && node test_smoke.js && node test_canonical.js && node test_search.js"
   },
   "keywords": [
     "defi",
@@ -41,6 +41,9 @@
     "fast-xml-parser": "^4.4.1"
   },
   "devDependencies": {
-    "playwright": "^1.61.1"
+    "@babel/standalone": "^8.0.4",
+    "playwright": "^1.61.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }

--- a/product-loop-kit/BACKLOG.md
+++ b/product-loop-kit/BACKLOG.md
@@ -20,5 +20,5 @@
 | 015 | Fix apex/referral share URL in tweet flow (redirect hygiene) | 6.0 | READY (heartbeat writes the spec) | LOW | — | 0 | — |
 | 016 | Re-brand empty-state buttons to neumorphic tokens | 7.2 | SHIPPED (PR #97, merged 2026-07-11) | LOW | specs/016.md | 1 | — |
 | 017 | NL search: every advertised typing-example must parse (solana/base/kamino lenders/curve/convex) | 8.4 | superseded by 018 — fixtures passed, product failed | HIGH | specs/017.md | 1 | — |
-| 018 | NL search actually works (behavior on live data, Playwright drives the real UI) | 9.0 | IN_PROGRESS (2026-07-11) | HIGH | specs/018.md | 1 | — |
+| 018 | NL search actually works (behavior on live data, Playwright drives the real UI) | 9.0 | IN_REVIEW (verifier PASS 2026-07-11, PR open) | HIGH | specs/018.md | 3 | — |
 | 019 | Pool-detail pages convert SEO landers toward the north star | 8.7 | READY | HIGH | specs/019.md | 0 | — |

--- a/product-loop-kit/BACKLOG.md
+++ b/product-loop-kit/BACKLOG.md
@@ -20,5 +20,5 @@
 | 015 | Fix apex/referral share URL in tweet flow (redirect hygiene) | 6.0 | READY (heartbeat writes the spec) | LOW | — | 0 | — |
 | 016 | Re-brand empty-state buttons to neumorphic tokens | 7.2 | SHIPPED (PR #97, merged 2026-07-11) | LOW | specs/016.md | 1 | — |
 | 017 | NL search: every advertised typing-example must parse (solana/base/kamino lenders/curve/convex) | 8.4 | superseded by 018 — fixtures passed, product failed | HIGH | specs/017.md | 1 | — |
-| 018 | NL search actually works (behavior on live data, Playwright drives the real UI) | 9.0 | READY | HIGH | specs/018.md | 0 | — |
+| 018 | NL search actually works (behavior on live data, Playwright drives the real UI) | 9.0 | IN_PROGRESS (2026-07-11) | HIGH | specs/018.md | 1 | — |
 | 019 | Pool-detail pages convert SEO landers toward the north star | 8.7 | READY | HIGH | specs/019.md | 0 | — |

--- a/product-loop-kit/specs/018-notes.md
+++ b/product-loop-kit/specs/018-notes.md
@@ -1,0 +1,129 @@
+# Notes: 018 — NL search actually works
+
+## Root causes found (all in `app.js`, inside `parseNaturalLanguageQuery` and its call sites — no per-string hacks)
+
+1. **The real bug behind "search is still very bad": `availableProtocols` was empty on the very first search.**
+   `availableProtocols` (app.js ~1416) only computed protocol stats once a chain
+   or token filter was *already* selected. On a fresh page load, before any
+   search, both are empty — so `availableProtocols.all` was always `[]` at
+   the exact moment `parseNaturalLanguageQuery` ran for the user's first
+   query. The parser then silently fell back to its ~26-entry hardcoded
+   static protocol list (`Aave`, `Curve`, `Convex`, `Morpho`, ... — no
+   `Kamino`). This is why "Kamino lending" — one of the four rotating
+   placeholder examples shown to every visitor — could fail while looking
+   like a parser problem. Fixed by adding a third branch to the memo: when
+   neither a chain nor a token is selected yet, compute across all pools.
+
+2. **Chain parsing only knew ~25 hardcoded aliases**, never checked the
+   query against the live chain list it was already given as a parameter.
+   "Lending on Plasma" failed because "Plasma" (a real, current chain) isn't
+   in the static `chainAliases` map. Fixed by falling back to a direct
+   word-boundary match against `allChains` (the live list) when no static
+   alias matches. Also hardened the static-alias loop itself to word-boundary
+   matching — the old plain `.includes()` meant alias `'op'` (Optimism) could
+   misfire inside an unrelated word like "top".
+
+3. **Protocol Method 2's trailing word-boundary re-check was actively wrong**
+   for any live friendly name that's a word-fragment. `getFriendlyProtocolName`
+   naively title-cases a DefiLlama slug (`kamino-lend` → `Kamino lend`) — a
+   truncated, not-a-real-word ending. The old code's `\bkamino lend\b` regex
+   requires a boundary immediately after "lend", which "Kamino lend*ing*"
+   never has, so it silently failed. Removed the redundant re-check (the
+   substring-containment check above it is already sufficient) and added a
+   reverse direction: a bare single-word query ("kamino") now also matches
+   when it's one of the words making up a longer friendly name.
+
+4. **"kamino lenders" didn't set the Lending pool-type** because the check
+   was a literal `.includes('lending')`; "lenders" doesn't contain that
+   string. Broadened to a word-boundary stem match, `/\blend(ing|ers?)?\b/`.
+
+5. **Protocol/pool-type-only queries with no chain and no token rendered
+   nothing.** Every render/empty-state gate in the file keys off
+   `selectedToken || (chainMode && selectedChain)` — "convex", "kamino
+   lending" (once #1 above is fixed to actually detect the protocol), and
+   "morpho lending" all resolve to a protocol with no chain (no entry in the
+   small `protocolChainMapping`), so neither side of that OR was ever true
+   and the results section literally never mounted. Rather than touching
+   the ~6 separate gate call sites, `handleKeyDown` now defaults such
+   queries into the existing "All chains" mode (the same mode the "All
+   chains" button already uses) — reusing its filtering and rendering path
+   instead of adding new states.
+
+## Deviations from spec
+
+- Spec's evidence section focuses on the parser; the single biggest fix
+  (root cause #1) is not in the parser at all — it's the `availableProtocols`
+  memo the parser is fed from. Fixing the parser alone (as 017 did) can
+  never fix this, because the parser was always being called with
+  correct-looking code and empty data. Flagging because it means "grep for
+  per-string hacks in the parser" isn't sufficient review coverage for this
+  bug class — the acceptance criterion about live-DOM assertion is what
+  actually caught it.
+- Kept the ~26-entry static protocol fallback list as-is (still used when
+  `availableProtocols.all` is genuinely empty, e.g. pools haven't loaded
+  yet) — didn't expand it, since fix #1 makes it a rare fallback rather than
+  the every-first-query path it accidentally was.
+- Did not touch `test_protocol_parsing.js` / `test_qualifier_fix.js` (the
+  stale inline-copy tests 017's evidence section flagged — they only
+  `console.log`, never assert). Out of scope for 018, which is behavior-only
+  per its own "OUT of scope: search UI redesign, router semantics, planner."
+  Left as a known follow-up.
+
+## Sandbox network limitation (read before re-running the Playwright test)
+
+This build ran in a network-policy-restricted session: outbound HTTPS to
+`unpkg.com` (React/ReactDOM/Babel) and `yields.llama.fi` (the live pools API)
+both return a proxy-level 403 (`/root/.ccr/README.md`: "destination host is
+not allowed by your organization's egress policy for this session... do not
+retry or route around it"). Verified directly with `curl` through the same
+proxy Chromium uses (Node's bare `https` module doesn't honor `HTTPS_PROXY`
+and gives a false "reachable" reading — learned this the hard way, see the
+probe implementation in `test_search.js`).
+
+`test_search.js` handles this without weakening the spec's "live data, not
+fixtures" requirement:
+- It probes both hosts via `curl` (proxy-honoring) before the run.
+- Where a host is reachable, it lets requests through untouched — in an
+  environment with full network access this test is 100% live: real
+  unpkg.com CDN, real `yields.llama.fi` response.
+- Where blocked (this sandbox), it intercepts via `page.route()`: React/
+  ReactDOM/Babel are served from local `node_modules` (added as
+  devDependencies, test-only — production `home.html` still points at
+  unpkg.com, untouched), and pools come from a DefiLlama-shaped fixture
+  snapshot (real project slugs, chain names, symbol conventions, TVL well
+  above `DEFAULT_MIN_TVL`).
+- Either way the test drives the real mounted React app and asserts on the
+  DOM — this is not 017's mistake (unit-testing an extracted function with
+  hand-picked mock lists, never mounting a browser). The only thing
+  substituted is the two network responses, and which mode ran is logged.
+
+**This session's run used the fixture fallback for both hosts** (confirmed
+403 via direct curl through the proxy). All 14/14 canonical-query assertions
+passed against the fixture. The human should be aware that a fully-live run
+(unpkg.com + yields.llama.fi both reachable) has not been exercised in this
+session — recommend a spot-check in an environment with full network access,
+or note that CI/verifier environments with different egress policy will
+exercise the live path automatically since the test's fallback is
+conditional, not hardcoded.
+
+## Test flakiness fixed along the way
+
+Initial version of the DOM assertion read `.pool-card` / `.pool-context-inline`
+once, right after `.results-section` became visible. That gate fires as soon
+as `chainMode`/`selectedChain` commit, but `filteredPools` itself settles one
+effect-pass later — so a single snapshot could catch the frame between "mode
+switched" and "pools actually filtered," intermittently reading a stale/empty
+`filteredPools`. Replaced the one-shot read with a bounded poll (8s cap,
+200ms interval) that re-checks until the assertion holds or the deadline
+passes — still fails hard on genuine breakage, just not on this harmless
+render-settling window.
+
+## Files touched
+
+- `app.js` — 5 fixes above (parser: chain matching, protocol matching,
+  pool-type stem match; render: `availableProtocols` memo, `handleKeyDown`
+  chain default)
+- `test_search.js` — new, wired into `npm test`
+- `package.json` / `package-lock.json` — `test_search.js` added to the test
+  chain; `react`, `react-dom`, `@babel/standalone` added as devDependencies
+  (test-only local vendoring, see network limitation above)

--- a/product-loop-kit/specs/018-notes.md
+++ b/product-loop-kit/specs/018-notes.md
@@ -25,6 +25,42 @@ negative regression set to `test_search.js` (`NEGATIVE_QUERIES`) asserting
 these queries produce no results section at all, so this exact bug class
 has direct test coverage and can't silently regress again.
 
+## Verifier round 2: FAIL, fixed
+
+The round-1 regression itself was confirmed genuinely fixed (verifier
+independently re-extracted and ran the parser against the 5 broken queries
+plus a ~30-word broader sweep, all clean). But it caught a second, separate
+gap: spec 018's own Measurement section commits to `search_success` /
+`search_abandonment` events, 14-day window — but `handleKeyDown`'s
+Enter-triggered NL-search branch (the exact code every fix in this diff
+lives inside) never called `Analytics.trackSearch*` at all. Those calls
+only existed on the autocomplete-select and chain-chip-click paths
+(`handleTokenSelect`, `handleChainSelect` — both pre-existing, untouched by
+this diff), not the typing+Enter flow this spec is entirely about. In-code
+comments (`app.js` — "Search input analytics disabled temporarily... TODO:
+Re-enable", "Search abandonment analytics disabled temporarily") show this
+was a known, deliberately-deferred gap predating 018, but the spec
+re-asserts this exact measurement plan for this exact change, so it needed
+wiring, not just disclosing.
+
+Fixed by calling the existing `Analytics.trackSearch(query, {...})` /
+`Analytics.trackSearchAbandonment(query, 0, {...})` helpers (same API
+`handleTokenSelect`/`handleChainSelect` already use — no new tracking
+methods invented) right after the NL parse resolves: success when the
+parse produced a token, chain, or protocol match; abandonment when it
+resolved to nothing actionable. `test_search.js` now spies on
+`Analytics.trackSearchSuccess`/`trackSearchAbandonment` (monkey-patched
+in-page before typing, since `Analytics.track()` itself no-ops when
+`mixpanel` isn't loaded — true in this sandbox, mp.defi.garden is blocked
+by the same egress policy as unpkg.com/yields.llama.fi) and asserts the
+right event fires for every one of the 19 canonical + negative queries.
+
+One known gap left as-is: `trackSearchAbandonment`'s `timeSpent` argument
+is passed as `0` — there's no existing "when did the user start typing"
+timestamp in scope to compute a real value, and inventing one felt like
+scope creep beyond what the spec asks for. `results_count`/`selected_*`
+fields are populated correctly; only the duration field is a placeholder.
+
 ## Prior attempt on this item (branch `claude/loop-018`, unmerged)
 
 A previous build session already picked up 018, hit the identical network
@@ -170,10 +206,14 @@ render-settling window.
 
 ## Files touched
 
-- `app.js` — 5 fixes above (parser: chain matching, protocol matching,
-  pool-type stem match; render: `availableProtocols` memo, `handleKeyDown`
-  chain default)
-- `test_search.js` — new, wired into `npm test`
+- `app.js` — 5 root-cause fixes above (parser: chain matching, protocol
+  matching, pool-type stem match; render: `availableProtocols` memo,
+  `handleKeyDown` chain default), the verifier-round-1 word-boundary
+  correction, and the verifier-round-2 `Analytics.trackSearch(Success|Abandonment)`
+  wiring in `handleKeyDown`
+- `test_search.js` — new, wired into `npm test`; 14 canonical + 5 negative
+  queries, each asserting rendered DOM correctness and that the matching
+  analytics event fired
 - `package.json` / `package-lock.json` — `test_search.js` added to the test
   chain; `react`, `react-dom`, `@babel/standalone` added as devDependencies
   (test-only local vendoring, see network limitation above)

--- a/product-loop-kit/specs/018-notes.md
+++ b/product-loop-kit/specs/018-notes.md
@@ -1,5 +1,30 @@
 # Notes: 018 — NL search actually works
 
+## Verifier round 1: FAIL, fixed
+
+The verifier subagent independently reproduced the Playwright run (green,
+twice) but caught a real regression by reading the actual diff rather than
+trusting this file's claims: the Method 2 protocol forward-match fix
+(then at app.js ~421) removed word-boundary checking *entirely* instead of
+narrowing it. That reopened false-positive substring matches for short
+single-word static-fallback aliases — `comp` (Compound), `bal` (Balancer),
+`joe` (Trader Joe) — so plausible retail-saver queries like "compare rates"
+or "global yields" silently resolved to one unrelated protocol's pools
+instead of no match. Confirmed by the verifier via direct before/after
+execution of the extracted function body, independent of any test file.
+
+Fixed by keeping a strict, both-ends `\bword\b` boundary for single-word
+aliases (restores original safety for `comp`/`bal`/`joe`/etc.), and only
+relaxing the *trailing* boundary for multi-word aliases (where the
+fragment-truncation problem — "kamino-lend" → "Kamino lend" — actually
+occurs; the first word of a multi-word phrase already carries enough
+specificity to keep this safe). Verified the fix against both the
+regression queries and all 14 canonical queries via a fast node-only
+harness before re-running the full Playwright suite. Added a 5-query
+negative regression set to `test_search.js` (`NEGATIVE_QUERIES`) asserting
+these queries produce no results section at all, so this exact bug class
+has direct test coverage and can't silently regress again.
+
 ## Prior attempt on this item (branch `claude/loop-018`, unmerged)
 
 A previous build session already picked up 018, hit the identical network

--- a/product-loop-kit/specs/018-notes.md
+++ b/product-loop-kit/specs/018-notes.md
@@ -1,5 +1,30 @@
 # Notes: 018 — NL search actually works
 
+## Prior attempt on this item (branch `claude/loop-018`, unmerged)
+
+A previous build session already picked up 018, hit the identical network
+wall (this sandbox's egress proxy 403s both `unpkg.com` and
+`yields.llama.fi`), and parked it as BLOCKED rather than attempt a fix —
+reasoning that mocking network data would repeat 017's exact mistake. That
+branch also carried forward 017's design: extracting `parseNaturalLanguageQuery`
+into a new `search-parser.js` module and wiring a `<script>` tag into
+`home.html` (the sacred router file) to load it.
+
+Main's `BACKLOG.md` never picked up that BLOCKED status (the commit marking
+it BLOCKED only exists on the unmerged branch), so this session's `git fetch`
++ pickup correctly found 018 still READY per build.md's rule of following
+BACKLOG.md's authoritative state — this is a fresh, independent attempt, not
+a continuation.
+
+This branch (`claude/loop-018-2`) takes a different, smaller path: fixes are
+made in place in `app.js` (no extraction, `home.html` untouched), and the
+network blocker is resolved rather than accepted — `test_search.js` probes
+reachability first and only substitutes locally when genuinely blocked (see
+"Sandbox network limitation" below), which is a materially different claim
+than 017's "mocked the parser function directly, never rendered anything."
+The prior branch is left as-is, unmerged and undeleted — worth a human
+decision on whether to delete it once this ships.
+
 ## Root causes found (all in `app.js`, inside `parseNaturalLanguageQuery` and its call sites — no per-string hacks)
 
 1. **The real bug behind "search is still very bad": `availableProtocols` was empty on the very first search.**

--- a/product-loop-kit/specs/018-pr.md
+++ b/product-loop-kit/specs/018-pr.md
@@ -1,0 +1,148 @@
+# PR explainer: 018 — NL search actually works (HIGH tier)
+
+## Goal
+
+The search box's own rotating placeholder examples ("USDC on Base", "Lending
+on Plasma", "CRV LP on Curve", "Kamino lending") — plus every bare
+chain/protocol query a cautious retail user would plausibly type ("solana",
+"curve", "convex", "kamino lenders", "morpho lending", "aave") — need to
+actually produce a correctly filtered, non-empty result grid whenever
+matching live pools exist. This is the analytics app's SEO-critical search
+surface; advertising an example that returns nothing is a broken funnel step,
+and per NORTH_STAR.md a bug at a funnel step outranks any experiment at that
+step.
+
+This is a rebuild of 017, which shipped 14/14 green parser-fixture tests
+while the actual product stayed broken in prod — because its acceptance bar
+only ever called the extracted parser function with hand-picked mock lists,
+never mounted a browser, never looked at a rendered DOM. 018 exists
+specifically so that failure mode can't repeat: every acceptance assertion
+here types into the real search input of the real mounted app and reads the
+real `.pool-card` elements it produces.
+
+## Intuition: why "Kamino lending" — a headline example — was actually broken
+
+The parser code looks reasonable in isolation, and if you unit-test it with
+a hand-built protocol list (exactly what 017 did), it passes. The real bug
+isn't in the parsing logic at all — it's in what data the parser gets called
+with. `availableProtocols`, the live list of "which protocols exist in the
+current pool data," only computed anything once a chain or token filter was
+*already* selected. Before the user's first search, neither is selected, so
+that list was always empty — and the parser silently fell back to a small
+~26-entry hardcoded protocol dictionary that doesn't include Kamino. A
+unit test of the parser function alone can never catch this, because the
+test supplies its own (non-empty) protocol list by hand — it never
+reproduces the actual empty-list condition the real app hits on every first
+keystroke.
+
+Four smaller, compounding bugs sit alongside it (see `specs/018-notes.md`
+for the full technical writeup): chain matching only knew ~25 hardcoded
+chain names and never checked the query against the live chain list it
+already had ("Plasma" isn't in the static list); a leftover word-boundary
+check in protocol matching required an exact word ending that a slug-derived
+name like "Kamino lend" can never have; "lenders" didn't match the string
+literal `"lending"`; and every render/empty-state gate in the file requires
+a token or a chain to be set, so a protocol-only match with no inferred
+chain (Convex, Morpho — no entry in the small chain-inference table)
+rendered nothing at all even once correctly parsed.
+
+## What changed and why (diff in reading order)
+
+**`app.js`, chain parsing (~line 264):** word-boundary-match the existing
+~25 short aliases (fixes a latent false-positive risk: alias `'op'` could
+misfire inside "top"), then fall back to matching any name in the live
+`allChains` list directly. This is the fix for "Lending on Plasma" — no
+hardcoded "Plasma" entry was ever added; the chain resolves because it's a
+real chain in the data the function was already given.
+
+**`app.js`, pool-type "Lending" detection (~line 296):** broadened
+`.includes('lending')` to a word-boundary stem regex
+`/\blend(ing|ers?)?\b/`, so "kamino lenders" sets the Lending pool type the
+same way "kamino lending" does.
+
+**`app.js`, protocol Method 2 (~line 410):** removed the trailing
+word-boundary re-check that silently killed matches against word-fragment
+friendly names, and added the reverse direction — a bare query word
+("kamino") now also matches when it's one of the words inside a longer live
+friendly name ("Kamino lend").
+
+**`app.js`, `availableProtocols` memo (~line 1452):** the actual headline
+fix. Added a third branch: when no chain or token filter is active yet,
+compute protocol stats across all pools instead of returning nothing. This
+is what makes the parser's live protocol context non-empty on a user's very
+first search.
+
+**`app.js`, `handleKeyDown` (~line 1882):** a protocol/pool-type match with
+no chain and no token (Convex, Morpho — protocols with no entry in the small
+chain-inference table) now defaults into the existing "All chains" display
+mode instead of resolving to an empty screen. This reuses the same
+filtering/rendering path the "All chains" button already exercises rather
+than adding new render-gate branches at the ~6 places that check
+`selectedToken || (chainMode && selectedChain)`.
+
+**`test_search.js` (new):** Playwright test driving the real mounted app —
+types all 14 canonical queries (every typing-placeholder example + every
+class of query the human reported failing), asserts the rendered grid is
+non-empty and that every card's `on {project} • {chain}` text and symbol
+actually match the query — not just that *something* rendered. Wired into
+`npm test`.
+
+## Deviation from spec worth flagging
+
+The spec's evidence section is framed around "root-cause the parser." The
+single biggest fix isn't in the parser — it's in the memo that feeds it live
+data. Grep-checking the parser for per-string hacks (which this diff has
+none of) would have missed this bug class entirely; only driving the real
+DOM caught it. See `specs/018-notes.md` for the full list of deviations,
+including a real environment constraint: this build's sandbox blocked
+outbound access to unpkg.com and yields.llama.fi (org egress policy, not a
+code issue), so `test_search.js` falls back to locally vendored
+React/Babel + a DefiLlama-shaped fixture snapshot in this environment. The
+test probes both hosts first and uses live requests wherever reachable, so
+in a network-unrestricted environment (or CI) it runs fully live. **A fully
+live run has not been exercised in this session — recommend a spot-check in
+an environment with full network access.**
+
+## Quiz
+
+1. What was the *actual* root cause of "Kamino lending" (a rotating
+   placeholder example) failing, as opposed to what it looked like from
+   reading the parser alone?
+   A. The word "lending" was misspelled in the placeholder string
+   B. `availableProtocols` was always empty on the user's first search, so the parser fell back to a static list that doesn't include Kamino
+   C. Kamino pools have TVL below `DEFAULT_MIN_TVL` and were filtered out
+   D. The router sent the query to the planner instead of the analytics app
+
+2. Why couldn't a unit test of the extracted parser function (017's
+   approach) ever have caught the `availableProtocols` bug?
+   A. Because such a test supplies its own protocol list by hand, so it never reproduces the real app's empty-list condition on first search
+   B. Because the parser function doesn't exist as a separate function
+   C. Because unit tests can't run in Node.js
+   D. Because the bug only occurs in Korean-language mode
+
+3. "Lending on Plasma" was fixed by:
+   A. Adding `'plasma': 'Plasma'` to the hardcoded `chainAliases` dictionary
+   B. Renaming the Plasma chain in the pool data
+   C. Falling back to matching any name in the live `allChains` list when no static alias matches
+   D. Special-casing the string "plasma" in `handleKeyDown`
+
+4. Why did "convex" and "morpho lending" render an empty screen even after
+   correctly parsing the protocol?
+   A. `APY_SANITY_LIMIT` excluded them as anomalous
+   B. Every render/empty-state gate requires a token or a chain to be set, and neither protocol has an entry in the small chain-inference table
+   C. The translations.js EN/KO strings were missing
+   D. `minTvl` defaulted to a value higher than any Convex pool's TVL
+
+5. Why does `test_search.js` sometimes serve React/Babel/pool data from
+   local fixtures instead of the real unpkg.com/yields.llama.fi endpoints?
+   A. This sandbox's org egress policy blocks those two hosts; the test probes reachability first and only falls back when blocked, using live requests wherever possible
+   B. Live data is intentionally never used, per spec, to keep the test deterministic
+   C. unpkg.com and yields.llama.fi are deprecated and being replaced permanently
+   D. It's a bug that should be fixed in a follow-up
+
+<details>
+<summary>Answers (base64)</summary>
+
+MS4gQgoyLiBBCjMuIEMKNC4gQgo1LiBB
+
+</details>

--- a/product-loop-kit/specs/018-pr.md
+++ b/product-loop-kit/specs/018-pr.md
@@ -60,9 +60,15 @@ real chain in the data the function was already given.
 `/\blend(ing|ers?)?\b/`, so "kamino lenders" sets the Lending pool type the
 same way "kamino lending" does.
 
-**`app.js`, protocol Method 2 (~line 410):** removed the trailing
-word-boundary re-check that silently killed matches against word-fragment
-friendly names, and added the reverse direction — a bare query word
+**`app.js`, protocol Method 2 (~line 410):** narrowed (not removed) the
+word-boundary check that silently killed matches against word-fragment
+friendly names — single-word aliases still require a strict, both-ends
+`\bword\b` boundary (this matters: a first pass at this fix removed the
+boundary entirely and reopened false-positive matches for short aliases
+like `comp`/`bal`/`joe`, caught by the verifier and fixed, see
+`specs/018-notes.md` "Verifier round 1"); only multi-word aliases relax the
+*trailing* boundary, since the fragment-truncation problem is specific to a
+phrase's last word. Also added the reverse direction — a bare query word
 ("kamino") now also matches when it's one of the words inside a longer live
 friendly name ("Kamino lend").
 

--- a/product-loop-kit/specs/018-pr.md
+++ b/product-loop-kit/specs/018-pr.md
@@ -86,12 +86,24 @@ filtering/rendering path the "All chains" button already exercises rather
 than adding new render-gate branches at the ~6 places that check
 `selectedToken || (chainMode && selectedChain)`.
 
+**`app.js`, `handleKeyDown` analytics (~line 1930):** wires
+`Analytics.trackSearch`/`Analytics.trackSearchAbandonment` — the exact
+`search_success`/`search_abandonment` events spec 018's own Measurement
+section commits to — into the Enter-triggered NL-search path. The verifier's
+second pass caught that these existed only on the autocomplete-select and
+chain-chip-click paths, never on the typing+Enter flow every fix in this
+diff lives inside, so the spec's stated success metric was structurally
+incapable of moving. Uses the same `Analytics.trackSearch(query, {...})`
+helper `handleTokenSelect`/`handleChainSelect` already call — no new
+tracking method invented.
+
 **`test_search.js` (new):** Playwright test driving the real mounted app —
 types all 14 canonical queries (every typing-placeholder example + every
-class of query the human reported failing), asserts the rendered grid is
-non-empty and that every card's `on {project} • {chain}` text and symbol
-actually match the query — not just that *something* rendered. Wired into
-`npm test`.
+class of query the human reported failing) plus 5 negative-regression
+queries, asserts the rendered grid is non-empty and correctly filtered
+(not just that *something* rendered), and that the matching
+`search_success`/`search_abandonment` analytics event actually fired.
+Wired into `npm test`.
 
 ## Deviation from spec worth flagging
 

--- a/test_search.js
+++ b/test_search.js
@@ -1,0 +1,251 @@
+/* Playwright behavior gate for NL search (spec 018): drives the REAL rendered
+   UI (npm run dev + chromium) — types every advertised/canonical query into
+   the real search input and asserts on the rendered grid, never on parser
+   return values. Root-cause bug precedent: spec 017 asserted only against an
+   extracted parser function with hand-picked fixtures; 14/14 fixtures passed
+   while the actual product stayed broken because nothing ever mounted a
+   browser or looked at the DOM. This file exists so that mistake can't repeat.
+
+   Live-data-shaped fixture: this run's sandbox blocks outbound access to
+   unpkg.com (React/Babel) and yields.llama.fi (pools) — a network-policy
+   403, not a code issue (see product-loop-kit/specs/018-notes.md). The test
+   probes both hosts first; where reachable it lets the real request through
+   (genuinely live), and only falls back to a local vendored copy / a
+   DefiLlama-shaped fixture snapshot where the host is unreachable, logging
+   which mode ran. In an environment with full network access this test
+   exercises fully live data end-to-end, exactly as the spec requires.
+
+   Run: node test_search.js */
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { chromium } = require('playwright');
+
+const PORT = 8792;
+const ROOT = __dirname;
+const MIME = {
+  '.html': 'text/html', '.js': 'application/javascript', '.css': 'text/css',
+  '.json': 'application/json', '.svg': 'image/svg+xml', '.woff2': 'font/woff2',
+  '.png': 'image/png', '.txt': 'text/plain', '.xml': 'application/xml'
+};
+// Matched against the failing resource's own URL (msg.location().url), not
+// msg.text() — Chromium's "Failed to load resource" text never includes the
+// URL itself. Fonts/analytics/protocol-name-cache are non-critical per
+// CLAUDE.md ("external font/analytics fetches fail locally; page errors are
+// not") and app.js already degrades them gracefully (protocols fetch fails
+// silently, analytics is fire-and-forget).
+const IGNORABLE_ERROR_PATTERN = /mp\.defi\.garden|cdn\.mxpnl\.com|mixpanel|api\.llama\.fi\/protocols|fontshare\.com/i;
+const CHROMIUM_EXECUTABLE = fs.existsSync('/opt/pw-browsers/chromium') ? '/opt/pw-browsers/chromium' : undefined;
+
+// --- DefiLlama-shaped fixture pools --------------------------------------
+// Realistic project slugs / chain names / symbol conventions, sized well
+// above DEFAULT_MIN_TVL ($10M) so trust-rail filtering never hides them.
+// Includes below-floor and off-topic noise pools so a query only surfaces
+// pools it should.
+function makePool(id, project, symbol, chain, tvlUsd, apyBase, poolMeta) {
+  const pool = { pool: id, project, symbol, chain, tvlUsd, apyBase: apyBase || 0, apyReward: 0 };
+  if (poolMeta) pool.poolMeta = poolMeta;
+  return pool;
+}
+
+const FIXTURE_POOLS = [
+  makePool('usdc-base-aave', 'aave-v3', 'USDC', 'Base', 45_000_000, 4.2),
+  makePool('usdc-base-moonwell', 'moonwell', 'USDC', 'Base', 20_000_000, 5.1),
+  makePool('usdt-plasma-aave', 'aave-v3', 'USDT', 'Plasma', 15_000_000, 6.0, 'Lending'),
+  makePool('usdc-plasma-euler', 'euler', 'USDC', 'Plasma', 12_000_000, 5.5, 'Lending'),
+  makePool('crv-eth-curve', 'curve-dex', 'CRV-ETH', 'Ethereum', 30_000_000, 8.0),
+  makePool('3crv-eth-curve', 'curve-dex', '3CRV', 'Ethereum', 60_000_000, 3.2),
+  makePool('usdc-sol-kamino', 'kamino-lend', 'USDC', 'Solana', 80_000_000, 7.5, 'Lending'),
+  makePool('sol-sol-kamino', 'kamino-lend', 'SOL', 'Solana', 40_000_000, 6.1, 'Lending'),
+  makePool('cvx-eth-convex', 'convex-finance', 'CVX-ETH', 'Ethereum', 25_000_000, 9.4),
+  makePool('3crv-eth-convex', 'convex-finance', '3CRV', 'Ethereum', 18_000_000, 4.4),
+  makePool('usdc-eth-morpho', 'morpho-blue', 'USDC', 'Ethereum', 55_000_000, 5.9, 'Lending'),
+  makePool('usdc-base-morpho', 'morpho-blue', 'USDC', 'Base', 33_000_000, 6.3, 'Lending'),
+  makePool('usdc-arb-aave', 'aave-v3', 'USDC', 'Arbitrum', 70_000_000, 4.8),
+  makePool('eth-eth-aave', 'aave-v3', 'ETH', 'Ethereum', 200_000_000, 2.9),
+  makePool('gmx-arb-gmx', 'gmx', 'GMX', 'Arbitrum', 90_000_000, 12.0),
+  makePool('arb-eth-camelot', 'camelot-v3', 'ARB-ETH', 'Arbitrum', 22_000_000, 15.0),
+  makePool('sol-usdc-raydium', 'raydium', 'SOL-USDC', 'Solana', 35_000_000, 20.0),
+  makePool('sol-sol-marinade', 'marinade', 'SOL', 'Solana', 60_000_000, 6.8),
+  makePool('eth-usdc-aerodrome', 'aerodrome-slipstream', 'ETH-USDC', 'Base', 50_000_000, 18.0),
+  makePool('usdc-base-compound', 'compound-v3', 'USDC', 'Base', 28_000_000, 4.0),
+  makePool('usdc-eth-sushi-belowfloor', 'sushiswap', 'USDC', 'Ethereum', 500_000, 9.0), // below $10M floor
+  makePool('eth-polygon-lido', 'lido', 'ETH', 'Polygon', 40_000_000, 3.5) // off-topic noise
+];
+
+const FIXTURE_RESPONSE = JSON.stringify({ status: 'success', data: FIXTURE_POOLS });
+
+// --- Canonical query set (spec 018 §3): every typing-animation example +
+// every human-reported failing class. Each card's rendered context line is
+// "on {pool.project} • {chain}" (translations.js onProtocolChain) — asserting
+// on that text (not just card count) proves the filter was actually applied,
+// not merely that *something* rendered. ----------------------------------
+const QUERIES = [
+  { q: 'USDC on Base', minCards: 1, context: ['base'], symbol: 'usdc' },
+  { q: 'Lending on Plasma', minCards: 1, context: ['plasma'] },
+  { q: 'CRV LP on Curve', minCards: 1, context: ['curve', 'ethereum'], symbol: 'crv' },
+  { q: 'Kamino lending', minCards: 1, context: ['kamino'] },
+  { q: 'solana', minCards: 1, context: ['solana'] },
+  { q: 'base', minCards: 1, context: ['base'] },
+  { q: 'kamino', minCards: 1, context: ['kamino'] },
+  { q: 'kamino lenders', minCards: 1, context: ['kamino'] },
+  { q: 'curve', minCards: 1, context: ['curve'] },
+  { q: 'convex', minCards: 1, context: ['convex'] },
+  { q: 'arbitrum', minCards: 1, context: ['arbitrum'] },
+  { q: 'morpho lending', minCards: 1, context: ['morpho'] },
+  { q: 'aave', minCards: 1, context: ['aave'] },
+  { q: 'usdc on base', minCards: 1, context: ['base'], symbol: 'usdc' }
+];
+
+let passed = 0;
+async function test(name, fn) {
+  try { await fn(); passed++; console.log('  ✓ ' + name); }
+  catch (err) { console.error('  ✗ ' + name + '\n    ' + err.message); process.exitCode = 1; }
+}
+
+function startServer() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const urlPath = decodeURIComponent(req.url.split('?')[0]);
+      const filePath = path.join(ROOT, urlPath === '/' ? 'home.html' : urlPath);
+      fs.readFile(filePath, (err, data) => {
+        if (err) { res.writeHead(404); res.end('not found'); return; }
+        res.writeHead(200, { 'Content-Type': MIME[path.extname(filePath)] || 'application/octet-stream' });
+        res.end(data);
+      });
+    });
+    server.listen(PORT, () => resolve(server));
+  });
+}
+
+// Quick outbound reachability probe via curl, which — unlike Node's bare
+// https module — honors HTTPS_PROXY the same way Chromium does. A raw
+// Node https.get would silently bypass the proxy and report false
+// positives (direct egress can succeed even when the policy proxy 403s
+// the same host). Sandbox egress policy 403s are immediate, so an 8s cap
+// is generous, not a real wait; never retried per /root/.ccr/README.md.
+function probe(url) {
+  try {
+    const code = execFileSync('curl', ['-sS', '-o', '/dev/null', '-w', '%{http_code}', '--max-time', '8', url], {
+      encoding: 'utf8'
+    });
+    return code.trim().startsWith('2') || code.trim().startsWith('3');
+  } catch (err) {
+    return false;
+  }
+}
+
+async function main() {
+  const unpkgReachable = probe('https://unpkg.com/react@18/umd/react.production.min.js');
+  const llamaReachable = probe('https://yields.llama.fi/pools');
+  console.log(`network: unpkg.com ${unpkgReachable ? 'reachable' : 'BLOCKED (using local vendored React/Babel)'}, ` +
+    `yields.llama.fi ${llamaReachable ? 'reachable (live data)' : 'BLOCKED (using DefiLlama-shaped fixture snapshot)'}`);
+
+  const server = await startServer();
+  const browser = await chromium.launch({ executablePath: CHROMIUM_EXECUTABLE });
+  try {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+    const pageErrors = [];
+    page.on('pageerror', (err) => pageErrors.push('pageerror: ' + err.message));
+    page.on('console', (msg) => {
+      if (msg.type() !== 'error') return;
+      const source = msg.location()?.url || '';
+      if (!IGNORABLE_ERROR_PATTERN.test(source) && !IGNORABLE_ERROR_PATTERN.test(msg.text())) {
+        pageErrors.push('console.error: ' + msg.text() + (source ? ' (' + source + ')' : ''));
+      }
+    });
+
+    if (!unpkgReachable) {
+      const nodeModules = path.join(ROOT, 'node_modules');
+      const vendored = {
+        'https://unpkg.com/react@18/umd/react.production.min.js':
+          path.join(nodeModules, 'react/umd/react.production.min.js'),
+        'https://unpkg.com/react-dom@18/umd/react-dom.production.min.js':
+          path.join(nodeModules, 'react-dom/umd/react-dom.production.min.js'),
+        'https://unpkg.com/@babel/standalone/babel.min.js':
+          path.join(nodeModules, '@babel/standalone/babel.min.js')
+      };
+      for (const [url, localPath] of Object.entries(vendored)) {
+        await page.route(url, (route) => route.fulfill({
+          status: 200, contentType: 'application/javascript', body: fs.readFileSync(localPath)
+        }));
+      }
+    }
+    if (!llamaReachable) {
+      await page.route('https://yields.llama.fi/pools', (route) => route.fulfill({
+        status: 200, contentType: 'application/json', body: FIXTURE_RESPONSE
+      }));
+    }
+    // api.llama.fi/protocols already fails silently in app.js when unreachable.
+
+    for (const { q, minCards, context, symbol } of QUERIES) {
+      await test(`"${q}" renders a correctly filtered, non-empty grid`, async () => {
+        await page.goto(`http://localhost:${PORT}/home.html?app=analytics`, { waitUntil: 'load', timeout: 20000 });
+        await page.waitForSelector('.search-input', { timeout: 15000 });
+        // Let the pools fetch resolve before typing (matches real user timing).
+        await page.waitForFunction(
+          () => document.querySelector('.search-input')?.placeholder?.length > 0,
+          { timeout: 15000 }
+        );
+        await page.waitForTimeout(1200);
+
+        const input = page.locator('.search-input');
+        await input.click();
+        await input.fill(q);
+        await input.press('Enter');
+
+        await page.waitForSelector('.results-section', { timeout: 10000 });
+
+        // Filtering settles across a render + a follow-up effect pass (the
+        // chain/protocol state commits, then the filteredPools effect runs).
+        // A single point-in-time snapshot can catch that intermediate frame,
+        // so poll for the settled, correctly-filtered state instead of
+        // reading once — this bounds the wait without being a fixed sleep.
+        const deadline = Date.now() + 8000;
+        let lastFailure = null;
+        for (;;) {
+          lastFailure = await page.evaluate(({ minCards, context, symbol }) => {
+            const cards = Array.from(document.querySelectorAll('.pool-card'));
+            if (cards.length < minCards) {
+              const emptyState = document.querySelectorAll('.empty-state').length > 0;
+              return `expected >=${minCards} rendered .pool-card, got ${cards.length} (empty-state shown: ${emptyState})`;
+            }
+            const contextTexts = Array.from(document.querySelectorAll('.pool-context-inline')).map((e) => e.textContent);
+            const symbolTexts = Array.from(document.querySelectorAll('.pool-symbol')).map((e) => e.textContent);
+            if (context) {
+              for (const needle of context) {
+                if (!contextTexts.every((t) => t.toLowerCase().includes(needle))) {
+                  return `expected every card's context to include "${needle}", got: ${JSON.stringify(contextTexts)}`;
+                }
+              }
+            }
+            if (symbol && !symbolTexts.every((t) => t.toLowerCase().includes(symbol))) {
+              return `expected every card's symbol to include "${symbol}", got: ${JSON.stringify(symbolTexts)}`;
+            }
+            return null;
+          }, { minCards, context: context || null, symbol: symbol || null });
+
+          if (!lastFailure) break;
+          if (Date.now() > deadline) throw new Error(lastFailure);
+          await page.waitForTimeout(200);
+        }
+      });
+    }
+
+    if (pageErrors.length) {
+      console.error('page errors during run:\n' + pageErrors.join('\n'));
+      process.exitCode = 1;
+    }
+    await page.close();
+  } finally {
+    await browser.close();
+    server.close();
+  }
+  console.log(passed + '/' + QUERIES.length + ' search behavior assertions passed');
+}
+
+main().catch((err) => {
+  console.error('test_search crashed: ' + err.message);
+  process.exitCode = 1;
+});

--- a/test_search.js
+++ b/test_search.js
@@ -140,6 +140,30 @@ function startServer() {
 // positives (direct egress can succeed even when the policy proxy 403s
 // the same host). Sandbox egress policy 403s are immediate, so an 8s cap
 // is generous, not a real wait; never retried per /root/.ccr/README.md.
+// Spy on Analytics.trackSearchSuccess/trackSearchAbandonment by wrapping
+// them in-page before the query is typed. Analytics.track() itself no-ops
+// when `mixpanel` isn't loaded (true in this sandbox — mp.defi.garden is
+// blocked, same policy as unpkg.com/yields.llama.fi), so this spy is what
+// proves the Enter-triggered NL-search path actually calls these — the
+// exact code path spec 018's own Measurement section commits to
+// (search_success / search_abandonment) and that shipped disconnected from
+// it until this fix.
+async function installAnalyticsSpy(page) {
+  await page.evaluate(() => {
+    window.__analyticsEvents = [];
+    const origSuccess = Analytics.trackSearchSuccess.bind(Analytics);
+    Analytics.trackSearchSuccess = (query, selectedResult, resultsCount, context) => {
+      window.__analyticsEvents.push({ type: 'search_success', query });
+      return origSuccess(query, selectedResult, resultsCount, context);
+    };
+    const origAbandon = Analytics.trackSearchAbandonment.bind(Analytics);
+    Analytics.trackSearchAbandonment = (query, timeSpent, context) => {
+      window.__analyticsEvents.push({ type: 'search_abandonment', query });
+      return origAbandon(query, timeSpent, context);
+    };
+  });
+}
+
 function probe(url) {
   try {
     const code = execFileSync('curl', ['-sS', '-o', '/dev/null', '-w', '%{http_code}', '--max-time', '8', url], {
@@ -204,11 +228,17 @@ async function main() {
           { timeout: 15000 }
         );
         await page.waitForTimeout(1200);
+        await installAnalyticsSpy(page);
 
         const input = page.locator('.search-input');
         await input.click();
         await input.fill(q);
         await input.press('Enter');
+
+        const events = await page.evaluate(() => window.__analyticsEvents);
+        if (!events.some((ev) => ev.type === 'search_success')) {
+          throw new Error(`expected a search_success analytics event, got: ${JSON.stringify(events)}`);
+        }
 
         await page.waitForSelector('.results-section', { timeout: 10000 });
 
@@ -253,12 +283,18 @@ async function main() {
         await page.goto(`http://localhost:${PORT}/home.html?app=analytics`, { waitUntil: 'load', timeout: 20000 });
         await page.waitForSelector('.search-input', { timeout: 15000 });
         await page.waitForTimeout(1200);
+        await installAnalyticsSpy(page);
 
         const input = page.locator('.search-input');
         await input.click();
         await input.fill(q);
         await input.press('Enter');
         await page.waitForTimeout(1500);
+
+        const events = await page.evaluate(() => window.__analyticsEvents);
+        if (!events.some((ev) => ev.type === 'search_abandonment')) {
+          throw new Error(`expected a search_abandonment analytics event, got: ${JSON.stringify(events)}`);
+        }
 
         // No token/chain/protocol intent in these queries means no display
         // mode should activate — the results section stays unmounted, same

--- a/test_search.js
+++ b/test_search.js
@@ -98,6 +98,21 @@ const QUERIES = [
   { q: 'usdc on base', minCards: 1, context: ['base'], symbol: 'usdc' }
 ];
 
+// --- Negative regression set --------------------------------------------
+// A prior version of the Method 2 protocol-forward-match fix dropped word-
+// boundary checking entirely instead of narrowing it, so short static-
+// fallback aliases ("comp", "bal", "joe") false-matched inside unrelated
+// words: "compare" -> Compound, "global" -> Balancer, "joel" -> Trader Joe.
+// These plausible retail-saver queries carry no protocol/chain/token intent
+// and must not resolve to a narrow, wrong result set.
+const NEGATIVE_QUERIES = [
+  'compare rates',
+  'global yields',
+  'joel wants some yield',
+  'comparison of yields',
+  'balance my portfolio'
+];
+
 let passed = 0;
 async function test(name, fn) {
   try { await fn(); passed++; console.log('  ✓ ' + name); }
@@ -233,6 +248,31 @@ async function main() {
       });
     }
 
+    for (const q of NEGATIVE_QUERIES) {
+      await test(`"${q}" does not false-match a protocol`, async () => {
+        await page.goto(`http://localhost:${PORT}/home.html?app=analytics`, { waitUntil: 'load', timeout: 20000 });
+        await page.waitForSelector('.search-input', { timeout: 15000 });
+        await page.waitForTimeout(1200);
+
+        const input = page.locator('.search-input');
+        await input.click();
+        await input.fill(q);
+        await input.press('Enter');
+        await page.waitForTimeout(1500);
+
+        // No token/chain/protocol intent in these queries means no display
+        // mode should activate — the results section stays unmounted, same
+        // as today's behavior for any non-matching query. If it renders
+        // pool cards, that's a false protocol match wrongly narrowing the
+        // grid instead of leaving the user's typed text alone.
+        const resultsSection = await page.locator('.results-section').count();
+        if (resultsSection > 0) {
+          const contextTexts = await page.locator('.pool-context-inline').allTextContents();
+          throw new Error(`expected no results section for a non-matching query, got cards: ${JSON.stringify(contextTexts)}`);
+        }
+      });
+    }
+
     if (pageErrors.length) {
       console.error('page errors during run:\n' + pageErrors.join('\n'));
       process.exitCode = 1;
@@ -242,7 +282,8 @@ async function main() {
     await browser.close();
     server.close();
   }
-  console.log(passed + '/' + QUERIES.length + ' search behavior assertions passed');
+  const total = QUERIES.length + NEGATIVE_QUERIES.length;
+  console.log(passed + '/' + total + ' search behavior assertions passed');
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

- Root-causes why NL search silently failed for plausible queries ("Kamino lending" — a rotating placeholder example — "Lending on Plasma", bare "curve"/"convex"/"kamino", "morpho lending", etc.): `availableProtocols` only computed live protocol data once a chain/token filter was *already* selected, so the parser's protocol context was always empty on a user's first search and silently fell back to a static ~26-entry list missing protocols like Kamino; chain matching only knew ~25 hardcoded aliases and never checked the live chain list it was already given (missed "Plasma"); a stale word-boundary check killed matches against slug-derived word-fragment friendly names ("Kamino lend"); "lenders" didn't match the literal string "lending"; and every render/empty-state gate required a token or chain, so protocol-only matches with no inferred chain rendered nothing.
- Adds `test_search.js`: Playwright driving the real mounted app — types 14 canonical queries + 5 negative-regression queries into the real search input, asserts on rendered DOM (`.pool-card`/`.pool-context-inline`/`.pool-symbol`), and asserts the correct `search_success`/`search_abandonment` analytics event fires. This is the acceptance bar spec 017 missed (it unit-tested an extracted parser function with hand-picked fixtures and never mounted a browser).
- Wires `Analytics.trackSearch`/`Analytics.trackSearchAbandonment` into the Enter-triggered NL-search path — spec 018's own named success metric never fired there before this change.

Full technical writeup, three rounds of independent verifier findings (a word-boundary regression and an instrumentation gap, both fixed and re-verified), and a disclosed sandbox network limitation: `product-loop-kit/specs/018-notes.md`. Reviewer walkthrough + 5-question quiz: `product-loop-kit/specs/018-pr.md`.

Note: a prior, separate build session already attempted this item on branch `claude/loop-018` (unmerged, parked BLOCKED after hitting the same sandbox network wall this PR resolves instead — see `018-notes.md` "Prior attempt" section). That branch is left as-is; worth a human decision on deleting it once this merges.

## Test plan

- [x] `node test_search.js` — 19/19 assertions pass (reproduced independently by the verifier across all 3 rounds)
- [x] `node test_planner.js` — 190 assertions pass
- [x] `node test_protocol_parsing.js` — pass
- [x] `node test_qualifier_fix.js` — pass
- [x] `node test_canonical.js` — 24 assertions pass
- [x] `node --check app.js` — syntax clean
- [ ] `node test_smoke.js` — not run in this sandbox (pre-existing, unrelated: this sandbox's egress policy blocks `unpkg.com`/`yields.llama.fi`, which `test_smoke.js` has no fallback for; `test_search.js` does, see notes)
- [x] Verifier subagent: 3 independent passes, final verdict PASS, risk tier HIGH (confirmed no trust-rail/router/SEO-surface/config touches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDfNNxEhxt8A91wkkKW7wi


---
_Generated by [Claude Code](https://claude.ai/code/session_01RDfNNxEhxt8A91wkkKW7wi)_