### PR TITLE
019: pool-detail pages convert SEO landers toward the north star

### DIFF
--- a/PoolDetail.js
+++ b/PoolDetail.js
@@ -6,6 +6,7 @@ function PoolDetail({
   onBack,
   resetApp,
   calculateYields,
+  futureValue,
   formatCurrency,
   formatAPY,
   formatUsd,
@@ -24,6 +25,14 @@ function PoolDetail({
   const _formatUsd = formatUsd || ((n, f) => '$' + Number(n || 0).toLocaleString('en-US', { maximumFractionDigits: f || 2 }));
   const _formatNum = formatNum || ((n) => Number(n || 0).toLocaleString('en-US'));
   const _formatApy = formatApy || ((pct) => Number(pct || 0).toLocaleString('en-US', { maximumFractionDigits: 2 }) + '%');
+  const _futureValue = futureValue || ((monthly, annualRatePct, years) => {
+    const P = Number(monthly) || 0;
+    const months = Math.round((Number(years) || 0) * 12);
+    const r = (Number(annualRatePct) || 0) / 100;
+    if (r === 0) return P * months;
+    const rm = r / 12;
+    return P * ((Math.pow(1 + rm, months) - 1) / rm);
+  });
   const [investmentAmount, setInvestmentAmount] = useState(1000);
   const [showAPYBreakdown, setShowAPYBreakdown] = useState(false);
   const [calculatorExpanded, setCalculatorExpanded] = useState(true);
@@ -163,6 +172,19 @@ function PoolDetail({
   };
 
   const riskAssessment = getRiskAssessment();
+
+  // Persona this pool's risk tier maps to in the planner (stable/rwa/degen —
+  // mirrors planner.js's PERSONAS thresholds, same 25/50 risk-score bands
+  // getRiskAssessment already uses above). Drives the "Garden this pool"
+  // deep link and whether the projection below applies the degen haircut.
+  const gardenPersona = riskAssessment.score <= 25 ? 'stable' : riskAssessment.score <= 50 ? 'rwa' : 'degen';
+  const isAnomalous = totalApy > APY_SANITY_LIMIT_LOCAL;
+  const applyDegenHaircut = gardenPersona === 'degen';
+  const PROJECTION_MONTHLY = 200;
+  const PROJECTION_YEARS = 5;
+  const projectionApy = applyDegenHaircut ? totalApy / 3 : totalApy;
+  const projectionAmount = _futureValue(PROJECTION_MONTHLY, projectionApy, PROJECTION_YEARS);
+  const gardenThisPoolHref = `plan.html?goal=retirement&pace=${gardenPersona}&monthly=${PROJECTION_MONTHLY}`;
 
   return React.createElement('div', {
     className: 'pool-detail-container',
@@ -442,11 +464,17 @@ function PoolDetail({
           // Divider
           React.createElement('div', { className: 'pool-action-divider' }),
 
-          // Primary CTA — planner
+          // Primary CTA — garden this pool (deep-links into the planner
+          // prefilled with a persona/goal/monthly matching this pool's risk tier)
           React.createElement('a', {
             className: 'cta-button-primary',
-            href: 'plan.html?fresh=1'
-          }, t ? t('plannerCta') : 'Plan my savings →'),
+            href: gardenThisPoolHref,
+            onClick: () => {
+              if (typeof Analytics !== 'undefined') {
+                Analytics.trackPoolClick(pool, 'garden_cta', { investmentAmount: PROJECTION_MONTHLY });
+              }
+            }
+          }, t ? t('gardenThisPoolCta') : 'Garden this pool →'),
           React.createElement('p', { className: 'pool-action-hint' },
             t ? t('plannerCtaHint') : 'No wallet needed'
           ),
@@ -598,6 +626,48 @@ function PoolDetail({
             opacity: 0.8
           }
         }, `Key factors: ${riskAssessment.factors.slice(0, 2).join(', ')}`)
+      )
+    ),
+
+    // Honest mini-projection — always visible, never collapsed
+    React.createElement('div', {
+      className: 'metric-card-simple animate-on-mount',
+      style: {
+        background: 'var(--color-background)',
+        borderRadius: 'var(--neuro-radius-lg)',
+        padding: '24px',
+        boxShadow: 'var(--neuro-shadow-raised)',
+        marginBottom: '32px',
+        textAlign: 'center'
+      }
+    },
+      React.createElement('div', {
+        style: {
+          fontSize: 'var(--font-size-sm)',
+          color: 'var(--color-text-secondary)',
+          marginBottom: '8px',
+          fontWeight: 'var(--font-weight-medium)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px'
+        }
+      }, t ? t('projectionHeading') : 'The Long Game'),
+      React.createElement('div', {
+        style: {
+          fontSize: 'var(--font-size-lg)',
+          fontWeight: 'var(--font-weight-bold)',
+          color: 'var(--color-text)',
+          lineHeight: '1.4'
+        }
+      }, t ? t('projectionBody', PROJECTION_MONTHLY, PROJECTION_YEARS, projectionAmount) :
+        `$${PROJECTION_MONTHLY}/mo in this pool grows to ~${_formatUsd(projectionAmount, 0)} in ${PROJECTION_YEARS}y at current rates.`),
+      applyDegenHaircut && React.createElement('div', { className: 'calc-warning' },
+        t ? t('poolDegenHaircutNote', _formatApy(totalApy)) : `Projected at ⅓ haircut (${_formatApy(totalApy)} headline) — farm rates decay. Active management required.`
+      ),
+      isAnomalous && React.createElement('div', { className: 'calc-warning' },
+        t ? t('calcAnomalyWarning') : '⚠ This rate is anomalous and almost certainly unsustainable.'
+      ),
+      React.createElement('div', { className: 'calc-disclaimer' },
+        t ? t('calcDisclaimer') : 'Estimates based on current rates — yields change constantly. Not financial advice.'
       )
     ),
 
@@ -1100,6 +1170,89 @@ function PoolDetail({
                 color: 'var(--color-text)'
               }
             }, poolType)
+          ),
+
+          // 30d Mean APY (if available) — substantiates whether today's rate is stable or a spike
+          (typeof pool.apyMean30d === 'number') && React.createElement('div', {
+            style: {
+              padding: '12px',
+              background: 'var(--color-background)',
+              borderRadius: 'var(--neuro-radius-sm)',
+              boxShadow: 'var(--neuro-shadow-subtle)',
+              textAlign: 'center'
+            }
+          },
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-xs)',
+                color: 'var(--color-text-secondary)',
+                marginBottom: '4px',
+                textTransform: 'uppercase'
+              }
+            }, t ? t('apyMean30d') : '30d Mean APY'),
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-sm)',
+                fontWeight: 'var(--font-weight-medium)',
+                color: 'var(--color-text)'
+              }
+            }, _formatApy(pool.apyMean30d))
+          ),
+
+          // Exposure (if available)
+          pool.exposure && React.createElement('div', {
+            style: {
+              padding: '12px',
+              background: 'var(--color-background)',
+              borderRadius: 'var(--neuro-radius-sm)',
+              boxShadow: 'var(--neuro-shadow-subtle)',
+              textAlign: 'center'
+            }
+          },
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-xs)',
+                color: 'var(--color-text-secondary)',
+                marginBottom: '4px',
+                textTransform: 'uppercase'
+              }
+            }, t ? t('exposure') : 'Exposure'),
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-sm)',
+                fontWeight: 'var(--font-weight-medium)',
+                color: 'var(--color-text)',
+                textTransform: 'capitalize'
+              }
+            }, pool.exposure)
+          ),
+
+          // IL Risk (if available) — flagged in warning color when present, never hidden
+          pool.ilRisk && React.createElement('div', {
+            style: {
+              padding: '12px',
+              background: 'var(--color-background)',
+              borderRadius: 'var(--neuro-radius-sm)',
+              boxShadow: 'var(--neuro-shadow-subtle)',
+              textAlign: 'center'
+            }
+          },
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-xs)',
+                color: 'var(--color-text-secondary)',
+                marginBottom: '4px',
+                textTransform: 'uppercase'
+              }
+            }, t ? t('ilRisk') : 'IL Risk'),
+            React.createElement('div', {
+              style: {
+                fontSize: 'var(--font-size-sm)',
+                fontWeight: 'var(--font-weight-medium)',
+                color: pool.ilRisk === 'yes' ? 'var(--color-warning)' : 'var(--color-text)',
+                textTransform: 'capitalize'
+              }
+            }, pool.ilRisk === 'yes' ? (t ? t('yes') : 'Yes') : (t ? t('no') : 'No'))
           )
         ),
 

--- a/app.js
+++ b/app.js
@@ -2305,6 +2305,18 @@ function App() {
     };
   };
 
+  // Future value of monthly contributions, compounded monthly — mirrors
+  // planner.js's futureValue exactly (duplicated, not imported: this repo has
+  // no build step linking app.js and planner.js, see STABLE_SYMBOLS above).
+  const futureValue = (monthly, annualRatePct, years) => {
+    const P = Number(monthly) || 0;
+    const months = Math.round((Number(years) || 0) * 12);
+    const r = (Number(annualRatePct) || 0) / 100;
+    if (r === 0) return P * months;
+    const rm = r / 12;
+    return P * ((Math.pow(1 + rm, months) - 1) / rm);
+  };
+
   // Quick preview calculation for card display
   const getQuickPreview = (pool) => {
     const totalApy = (pool.apyBase || 0) + (pool.apyReward || 0);
@@ -2399,6 +2411,7 @@ function App() {
           onBack: handleBackFromDetail,
           resetApp: resetApp,
           calculateYields: calculateYields,
+          futureValue: futureValue,
           formatCurrency: formatCurrency,
           formatAPY: formatAPY,
           formatUsd: formatUsd,

--- a/product-loop-kit/BACKLOG.md
+++ b/product-loop-kit/BACKLOG.md
@@ -21,4 +21,4 @@
 | 016 | Re-brand empty-state buttons to neumorphic tokens | 7.2 | SHIPPED (PR #97, merged 2026-07-11) | LOW | specs/016.md | 1 | — |
 | 017 | NL search: every advertised typing-example must parse (solana/base/kamino lenders/curve/convex) | 8.4 | superseded by 018 — fixtures passed, product failed | HIGH | specs/017.md | 1 | — |
 | 018 | NL search actually works (behavior on live data, Playwright drives the real UI) | 9.0 | SHIPPED (PR #99, merged 2026-07-11; measuring search_success/search_abandonment) | HIGH | specs/018.md | 3 | 2026-07-25 |
-| 019 | Pool-detail pages convert SEO landers toward the north star | 8.7 | READY | HIGH | specs/019.md | 0 | — |
+| 019 | Pool-detail pages convert SEO landers toward the north star | 8.7 | IN_PROGRESS (2026-07-11) | HIGH | specs/019.md | 1 | — |

--- a/product-loop-kit/specs/019-notes.md
+++ b/product-loop-kit/specs/019-notes.md
@@ -1,0 +1,63 @@
+# 019 — implementation notes
+
+## Deviations from spec (conservative choices, logged for the improve loop)
+
+1. **"futureValue helper" is duplicated, not imported.** app.js and PoolDetail.js
+   (analytics-app surface) have zero code sharing with planner.js — this is an
+   existing, documented constraint (see app.js's own comment above
+   `STABLE_SYMBOLS`: "this repo has no build step or module system linking
+   app.js and planner.js, so each browser script is self-contained"). The same
+   pattern already covers `APY_SANITY_LIMIT`/`formatUsd`/`formatApy` (each
+   independently redefined in PoolDetail.js as `APY_SANITY_LIMIT_LOCAL` /
+   fallback formatters). `futureValue` here follows that exact precedent:
+   defined once in app.js, passed down as a prop, with a matching fallback
+   inside PoolDetail.js for the no-prop (SSR/test) case — same shape as the
+   existing `_formatUsd`/`_formatNum`/`_formatApy` fallbacks already in the file.
+
+2. **"Deep-link prefilled with this pool" does not pin the literal pool.**
+   The planner has no concept of an individual pool — by design (trust rails:
+   it always curates/blends across multiple pools passing `DEFAULT_MIN_TVL` +
+   `APY_SANITY_LIMIT`, never quotes a single named pool's rate as a plan's
+   APY). Spec's own OUT-of-scope list forbids touching "planner internals," so
+   adding single-pool-pinning to the planner was not an option. Instead the
+   CTA reuses the planner's existing, stable, already-public URL contract (the
+   same `goal`/`pace`/`monthly` params the share-plan feature already uses,
+   see `decodePlanFromUrl` in planner.js) to prefill: `goal=retirement`
+   (the most generic growth goal), `pace=<persona>` mapped from this pool's
+   risk tier (stable/rwa/degen — using the exact same 25/50 risk-score bands
+   `getRiskAssessment()` already computes), and `monthly=200` (the same
+   illustrative amount shown in the mini-projection immediately above the
+   CTA, so the number the user just saw carries through). Zero planner.js
+   edits.
+
+3. **Persona→degen-haircut condition.** Spec says "degen haircut where
+   applicable" without defining "applicable" for a single pool (the haircut
+   is persona-scoped in planner.js, not pool-scoped). Applied it when this
+   pool's risk tier maps to the `degen` persona band (score > 50, includes
+   the anomalous-APY forced-High case) — i.e. the same condition that sends
+   the "Garden this pool" CTA into the degen persona. Reuses the existing
+   `degenHaircutNote` translation key verbatim (already used by planner.js
+   for the identical disclosure).
+
+4. **Trust-data fields (30d mean APY / exposure / IL risk) render only when
+   present on the pool object** (`typeof pool.apyMean30d === 'number'`,
+   `pool.exposure`, `pool.ilRisk` truthy) — these are DefiLlama pool-API
+   fields not present on every pool. No new fetch; same `pool` object already
+   passed into the component today.
+
+5. **`plannerCta` translation key removed** (both en/ko) rather than left
+   dead — it was referenced from exactly one call site (PoolDetail.js's old
+   CTA), now replaced by `gardenThisPoolCta`. Verified via repo-wide grep that
+   no other file referenced it.
+
+## Not touched (per spec's OUT-of-scope)
+- Router semantics / `?pool=` URL behavior
+- Trust-rail values (`APY_SANITY_LIMIT`, `DEFAULT_MIN_TVL`)
+- planner.js internals (no edits to that file at all)
+
+## Test run
+- `node test_planner.js && node test_protocol_parsing.js && node test_qualifier_fix.js` — 190/190 assertions, exit 0 (unaffected by this diff, which is app.js/PoolDetail.js/translations.js only).
+- `npm test`'s Playwright suite (test_smoke.js/test_canonical.js/test_search.js) hung past the 5-minute foreground timebox in this sandbox (real-network `page.goto` against `yields.llama.fi` with no mock, same class of sandbox network-policy friction noted in the 018 log entry) — killed per standing decision (never wait unbounded) rather than blocking on it.
+- In its place, wrote `specs/019-verify-manual.js` (mocked network via `page.route`, vendors local React/Babel/Babel-standalone like test_search.js does when unpkg.com is blocked) and drove the real `/?pool=` route for 3 fixture pools — low-risk (stable), medium-risk (rwa), and an anomalous >1000% APY pool. All 3 pass: exactly one CTA, href carries `goal=`/`pace=`/`monthly=`, projection text renders, anomalous pool shows `.calc-warning`, zero page errors. Deleted after use — not committed (ad hoc, not part of the permanent suite).
+- **Bug found + fixed during this check**: the first pass, `degenHaircutNote` (reused from planner.js's translation key) rendered as the literal string `"degenHaircutNote"` instead of the disclosure text. Root cause: that key lives nested under `translations.en.planner.*`, but PoolDetail.js's `t()` (app.js's `createTranslationFunction`) does a flat `translations[language][key]` lookup with no `planner.` nesting — the two translation namespaces aren't interchangeable. Fixed by adding a new flat key `poolDegenHaircutNote` (en+ko) instead of reusing the nested one.
+- **Pre-existing rendering anomaly found, NOT fixed (out of scope)**: in this sandbox's headless-Chromium screenshot, the hero's right-column action card (APY value + primary CTA button + secondary protocol link) renders visually blank/invisible even on unmodified `origin/main` — confirmed by temporarily reverting PoolDetail.js/app.js to the committed version and reproducing the identical blank region before reapplying this diff. The DOM content itself is correct in both cases (Playwright locator/text/attribute assertions all pass); only the pixel paint in this specific harness is affected, isolated to that one sub-tree. Everything this spec added (mini-projection card, trust-data grid cells) lives in separate sibling containers and renders fully visibly in the same screenshots. Flagging for the human/next loop to check on a real device — not touched here per spec's "smallest change" scope.

--- a/product-loop-kit/specs/019-pr.md
+++ b/product-loop-kit/specs/019-pr.md
@@ -1,0 +1,145 @@
+# PR explainer: 019 — Pool-detail pages convert SEO landers toward the north star (HIGH tier)
+
+## Goal
+
+Token-search visitors land on `?pool=` pages (the sacred SEO surface) that
+today look sparse: a bare TVL/APY hero and one link to the planner with no
+context. This is exactly where the SEO lifeline meets the product — and per
+NORTH_STAR.md's weekly theme ("SEO-landers to north star: search that works,
+pool-detail pages that convert") it's the highest-scored READY item this
+week. The ICP (a cautious retail saver) converts on trust and honest numbers,
+not APY hype, so the goal is to substantiate trust with data the app already
+has, add one honest concrete projection, and give exactly one CTA that
+carries the visitor's context into a plan — never inventing a rate, never
+hiding an anomaly.
+
+## Intuition: why the planner can't just "prefill this one pool"
+
+The obvious reading of "deep-link prefilled with this pool" is to pass the
+pool's own id/APY into the planner and have it show that exact pool. But the
+planner is deliberately built to never do that — by design, it always
+curates/blends across multiple pools clearing `DEFAULT_MIN_TVL` +
+`APY_SANITY_LIMIT`, and never quotes a single named pool's rate as a plan's
+APY (that's the trust rail: one pool's rate can vanish or turn out to be a
+data artifact; a blended rate from several pools passing the sanity filter
+is what the planner promises). Spec 019 also explicitly puts "planner
+internals" out of scope. So "prefilled with this pool" here means: prefilled
+with the *risk band* this pool belongs to (stable/rwa/degen — the planner's
+own three personas) plus a monthly amount, using the planner's existing,
+already-public share-plan URL contract (`goal`/`pace`/`monthly` —
+`decodePlanFromUrl` in planner.js, the same params a shared plan link already
+uses). Zero lines of planner.js changed.
+
+## What changed and why (diff in reading order)
+
+**`app.js`, new `futureValue` helper (~line 2308):** compounding-monthly-
+contribution formula, defined once and passed down as a prop — byte-for-byte
+the same formula as `planner.js`'s `futureValue` (line 79). Not imported:
+this repo already established the pattern (see the comment above
+`STABLE_SYMBOLS` in app.js) that app.js/PoolDetail.js and planner.js share no
+module system, so constants/formatters get duplicated on purpose rather than
+faked-shared. `futureValue` follows the same shape as the existing
+`_formatUsd`/`_formatNum`/`_formatApy` fallback trio already in
+PoolDetail.js.
+
+**`PoolDetail.js`, persona + projection (~line 173-186):** computes
+`gardenPersona` from the risk score `getRiskAssessment()` already produces
+(same 25/50 bands the risk card already uses — no new thresholds invented),
+whether the ⅓ degen haircut applies (`gardenPersona === 'degen'`), and the
+projection amount for a fixed $200/mo over 5 years at the pool's (possibly
+haircut) rate.
+
+**`PoolDetail.js`, mini-projection card (~line 632-670):** new card, always
+visible (never collapsed, unlike the calculator below it), reusing the exact
+inline-style tokens the rest of the file already uses (`--neuro-radius-lg`,
+`--neuro-shadow-raised`) and the pre-existing `.calc-warning`/
+`.calc-disclaimer` classes for the degen-haircut note, anomaly warning, and
+disclaimer — zero new CSS.
+
+**`PoolDetail.js`, trust-data grid cells (~line 1176-1257):** three new cells
+(30d mean APY, exposure, IL risk) appended to the *existing* APY-breakdown
+grid inside Pool Information, each only rendering when the field is present
+on the `pool` object already in hand (no new fetch) — copy-pasted cell
+markup pattern, not a new component.
+
+**`PoolDetail.js`, CTA (~line 464-476):** renamed "Garden this pool", href
+now `plan.html?goal=retirement&pace=${gardenPersona}&monthly=200` instead of
+the old bare `plan.html?fresh=1`, and instrumented via the pre-existing
+`Analytics.trackPoolClick(pool, 'garden_cta', {...})` — the same tracking
+call already used for the protocol link, just a different `click_type`
+value, not a new event.
+
+**`translations.js`:** 9 new keys added to both `en` and `ko` in the same
+edit (`gardenThisPoolCta`, `apyMean30d`, `exposure`, `ilRisk`, `yes`, `no`,
+`projectionHeading`, `projectionBody`, `poolDegenHaircutNote`); the old
+`plannerCta` key (superseded, single call site) removed from both languages
+rather than left dead.
+
+## Deviations worth flagging
+
+1. **`degenHaircutNote` reuse attempt failed, fixed during manual
+   verification.** First pass tried to reuse planner.js's existing
+   `degenHaircutNote` translation key. It rendered as the literal string
+   `"degenHaircutNote"` — that key lives nested under
+   `translations.en.planner.*`, but PoolDetail.js's `t()` (app.js's
+   `createTranslationFunction`) does a flat `translations[language][key]`
+   lookup with no `planner.` nesting. The two translation namespaces aren't
+   interchangeable. Fixed by adding a new flat key, `poolDegenHaircutNote`.
+2. **Deep-link goal defaults to `retirement`**, the most generic growth goal,
+   since the pool page has no way to know the visitor's actual life goal —
+   logged in `specs/019-notes.md`.
+3. **`npm test`'s Playwright suite** (test_smoke/test_canonical/test_search)
+   hung past the 5-minute foreground timebox in this sandbox on a real
+   network call to `yields.llama.fi` with no mock — killed per the
+   never-wait-unbounded standing decision. In its place, an ad hoc mocked
+   Playwright script (deleted after use, not part of the permanent suite)
+   drove the real `/?pool=` route for a stable/rwa/anomalous fixture trio;
+   all three passed (exactly one CTA, correct prefill params, projection
+   renders, anomaly warning visible, zero page errors). See
+   `specs/019-notes.md` for the full account, including a pre-existing
+   headless-rendering anomaly found and ruled out as unrelated to this diff
+   (reproduces identically on unmodified `origin/main`).
+
+## Quiz
+
+1. Why doesn't the "Garden this pool" CTA deep-link the planner to show this
+   *exact* pool's rate?
+   A. It's a bug that should be fixed in a follow-up
+   B. The planner is designed to always blend/curate across multiple trust-rail-passing pools, never quote one named pool's rate as a plan's APY — and spec 019 puts planner internals out of scope
+   C. The planner doesn't accept any URL parameters
+   D. Pool ids aren't unique across chains
+
+2. Where does the persona (`stable`/`rwa`/`degen`) used in the deep-link
+   come from?
+   A. A new classifier added to planner.js for this feature
+   B. Randomly assigned per page load
+   C. The same 25/50 risk-score bands `getRiskAssessment()` already computes for the Risk Assessment card
+   D. The pool's TVL alone
+
+3. What was wrong with the first attempt to show the degen-haircut
+   disclosure text?
+   A. It reused planner.js's `degenHaircutNote` key, which lives nested under `translations.en.planner.*` — but PoolDetail.js's flat `t()` lookup can't reach it, so it rendered the literal string "degenHaircutNote"
+   B. The English and Korean copy didn't match
+   C. The haircut math itself was wrong
+   D. The key didn't exist in either language
+
+4. Why do the new 30d-mean-APY/exposure/IL-risk cells never trigger a new
+   network request?
+   A. They're hardcoded placeholder values
+   B. They read fields (`apyMean30d`/`exposure`/`ilRisk`) already present on the same `pool` object the page already fetched
+   C. They're computed client-side from the APY breakdown
+   D. They only render in a debug mode
+
+5. Why wasn't `npm test`'s Playwright suite re-run to completion in this
+   session?
+   A. It's disabled for pool-detail changes
+   B. It hit a real-network call to `yields.llama.fi` with no mock and hung past the 5-minute foreground timebox in this sandbox — killed per standing decision, with a mocked substitute run in its place
+   C. It doesn't cover PoolDetail.js
+   D. Playwright isn't installed in this repo
+
+<details>
+<summary>Answers (base64)</summary>
+
+MS4gQgoyLiBBCjMuIEEKNC4gQgo1LiBC
+
+</details>

--- a/product-loop-kit/specs/019-pr.md
+++ b/product-loop-kit/specs/019-pr.md
@@ -140,6 +140,6 @@ rather than left dead.
 <details>
 <summary>Answers (base64)</summary>
 
-MS4gQgoyLiBBCjMuIEEKNC4gQgo1LiBC
+MS4gQgoyLiBDCjMuIEEKNC4gQgo1LiBC
 
 </details>

--- a/translations.js
+++ b/translations.js
@@ -30,7 +30,7 @@ const translations = {
     baseApyBreakdown: (apy) => `${apy}% Base`,
     rewardApyBreakdown: (apy) => `+ ${apy}% Rewards`,
     opensProtocol: "Opens protocol • Wallet required",
-    plannerCta: "Plan my savings →",
+    gardenThisPoolCta: "Garden this pool →",
     plannerCtaHint: "No wallet needed",
     protocol: "Protocol↗",
     calculateYield: "View & calculate →",
@@ -80,7 +80,17 @@ const translations = {
     verified: "✓ Verified",
     onProtocolChain: (protocol, chain, hasUrl) => `on ${protocol} • ${chain}${hasUrl ? ' ↗' : ''}`,
     tvl: "TVL",
-    
+    apyMean30d: "30d Mean APY",
+    exposure: "Exposure",
+    ilRisk: "IL Risk",
+    yes: "Yes",
+    no: "No",
+
+    // Honest mini-projection (pool-detail)
+    projectionHeading: "The Long Game",
+    projectionBody: (monthly, years, amount) => `$${Number(monthly || 0).toLocaleString('en-US')}/mo in this pool grows to ~$${Number(amount || 0).toLocaleString('en-US', { maximumFractionDigits: 0 })} in ${years}y at current rates.`,
+    poolDegenHaircutNote: (headline) => `Projected at ⅓ haircut (${headline} headline) — farm rates decay. Active management required.`,
+
     // Calculator disclaimers
     calcDisclaimer: "Estimates based on current rates — yields change constantly. Not financial advice.",
     calcAnomalyWarning: "⚠ This rate is anomalous and almost certainly unsustainable.",
@@ -516,7 +526,7 @@ const translations = {
     baseApyBreakdown: (apy) => `${apy}% 기본`,
     rewardApyBreakdown: (apy) => `+ ${apy}% 보상`,
     opensProtocol: "프로토콜 열기 • 지갑 필요",
-    plannerCta: "저축 플랜 만들기 →",
+    gardenThisPoolCta: "이 풀 가든하기 →",
     plannerCtaHint: "지갑 불필요",
     protocol: "프로토콜↗",
     calculateYield: "보기 및 계산 →",
@@ -566,7 +576,17 @@ const translations = {
     verified: "✓ 인증됨",
     onProtocolChain: (protocol, chain, hasUrl) => `${protocol}에서 • ${chain}${hasUrl ? ' ↗' : ''}`,
     tvl: "TVL",
-    
+    apyMean30d: "30일 평균 APY",
+    exposure: "익스포저",
+    ilRisk: "비영구적 손실 위험",
+    yes: "있음",
+    no: "없음",
+
+    // Honest mini-projection (pool-detail)
+    projectionHeading: "장기적으로 보면",
+    projectionBody: (monthly, years, amount) => `이 풀에 월 ${formatKoreanCurrency(monthly)}을 넣으면 ${years}년 후 현재 수익률 기준 약 ${formatKoreanCurrency(Number(amount || 0))}이 됩니다.`,
+    poolDegenHaircutNote: (headline) => `⅓ 할인 적용 (헤드라인 ${headline}) — 팜 수익률은 빠르게 감소. 적극적 관리 필요.`,
+
     // Calculator disclaimers
     calcDisclaimer: "현재 수익률 기준 추정치이며 수시로 변동됩니다. 투자 조언이 아닙니다.",
     calcAnomalyWarning: "⚠ 이 수익률은 비정상적이며 거의 지속 불가능합니다.",


### PR DESCRIPTION
## Summary
- Adds an honest mini-projection ("$200/mo in this pool grows to ~$X in 5y at current rates") to `PoolDetail.js`, using a `futureValue` compounding helper mirroring `planner.js`'s formula, with the same ⅓ degen-haircut disclosure applied when the pool's risk tier maps to the degen persona band
- Extends the existing pool-info grid with 30d mean APY / exposure / IL-risk cells when present on the pool object (no new fetches — same `pool` object already in hand)
- Renames the primary CTA to **"Garden this pool"** and deep-links it into the planner prefilled via the existing shareable-plan URL contract (`goal`/`pace`/`monthly`) — persona (`stable`/`rwa`/`degen`) mapped from the pool's own risk score, zero `planner.js` changes
- Instruments the CTA click via the existing `Analytics.trackPoolClick` pattern (`click_type: garden_cta`) for CTA→`plan_created` measurement
- EN + KO translations added together for every new string; removed the now-dead `plannerCta` key

## Test plan
- [x] `node test_planner.js && node test_protocol_parsing.js && node test_qualifier_fix.js` — 190/190 assertions, exit 0
- [x] Mocked-network Playwright run against the real `/?pool=` route across 3 fixture pools (low/medium/anomalous risk) — exactly one CTA, correct prefill params, projection renders, anomaly warning stays visible, zero page errors
- [ ] `npm test`'s full Playwright suite (test_smoke/test_canonical/test_search) hit a real-network hang against `yields.llama.fi` in this sandbox past the 5-minute timebox; not a regression from this diff (unrelated to PoolDetail/app.js) — flagged in `specs/019-notes.md` for a follow-up run with reachable network

See `product-loop-kit/specs/019-notes.md` for deviations from spec (all conservative/documented) and a pre-existing headless-rendering anomaly found (and ruled out as unrelated to this diff) during manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AUj7YW6U8Y4eUVWP16tzGH)_