### PR TITLE
020: real results_count on search_success + pool_view on ?pool= landings

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -156,6 +156,7 @@ const Analytics = {
     this.track('pool_view', {
       ...poolAnalytics,
       source_view: context.sourceView || 'search',
+      source: context.source || 'card_click',
       source_position: context.position || -1,
       search_query: context.searchQuery || null,
       active_filters: this.serializeFilters(context.filters || {}),

--- a/app.js
+++ b/app.js
@@ -1752,18 +1752,11 @@ function App() {
     setCurrentPage(1); // Reset to first page when filters change
   }, [selectedToken, selectedChain, selectedPoolTypes, selectedProtocols, minTvl, minApy, pools, chainMode, sortBy, userSortedApy]);
 
-  // Fire the NL-Enter search_success event once filteredPools has settled for
-  // that search, so results_count reflects what actually rendered instead of
-  // a value guessed synchronously at parse time (filteredPools is still stale
-  // in the same tick the Enter handler sets selectedToken/selectedChain).
+  // Fire the NL-Enter search_success event once filteredPools has settled
+  // (it's still stale in the same tick the Enter handler sets it, and can
+  // pass through an intermediate value before settling — debounce absorbs both).
   useEffect(() => {
     if (!pendingNlSearchTrackRef.current) return;
-    // filteredPools can pass through more than one value while a search
-    // settles (this same file's filter effect can recompute across more
-    // than one dependency change in a row); debounce so this only reads
-    // the final, settled count instead of whichever pass happens to land
-    // first — a plain single-fire-on-first-change was observed to
-    // occasionally catch an intermediate value.
     const timer = setTimeout(() => {
       const pending = pendingNlSearchTrackRef.current;
       if (!pending) return;
@@ -1958,9 +1951,7 @@ function App() {
           // selection paths already wired below in handleChainSelect /
           // handleTokenSelect.
           if (token || effectiveChain || protocols.length > 0) {
-            // filteredPools hasn't recomputed for this search yet in this
-            // same tick — stash it and let the effect above fire once it has
-            // the real count, instead of hardcoding results_count to 0.
+            // Let the effect above fire once it has the real count.
             pendingNlSearchTrackRef.current = {
               query,
               selectedResult: token || effectiveChain || '',

--- a/app.js
+++ b/app.js
@@ -782,6 +782,8 @@ function App() {
   const [chainMode, setChainMode] = useState(false); // Track if we're in chain-first mode
   const [currentView, setCurrentView] = useState('search'); // 'search' or 'pool-detail'
   const [detailPool, setDetailPool] = useState(null); // Pool being viewed in detail
+  const urlDirectPoolViewFiredRef = useRef(null); // pool id already tracked as a url_direct landing, prevents double-fire vs card click
+  const pendingNlSearchTrackRef = useRef(null); // NL-Enter search awaiting a real results_count once filteredPools settles
 
   // Language state management
   const [language, setLanguage] = useState(() => {
@@ -1018,6 +1020,11 @@ function App() {
           setDetailPool(foundPool);
           setCurrentView('pool-detail');
           document.title = `${foundPool.symbol} on ${foundPool.project} | DeFi Garden 🌱`;
+
+          if (urlDirectPoolViewFiredRef.current !== foundPool.pool) {
+            urlDirectPoolViewFiredRef.current = foundPool.pool;
+            Analytics.trackPoolView(foundPool, { source: 'url_direct' });
+          }
         }
       }
     }
@@ -1745,6 +1752,27 @@ function App() {
     setCurrentPage(1); // Reset to first page when filters change
   }, [selectedToken, selectedChain, selectedPoolTypes, selectedProtocols, minTvl, minApy, pools, chainMode, sortBy, userSortedApy]);
 
+  // Fire the NL-Enter search_success event once filteredPools has settled for
+  // that search, so results_count reflects what actually rendered instead of
+  // a value guessed synchronously at parse time (filteredPools is still stale
+  // in the same tick the Enter handler sets selectedToken/selectedChain).
+  useEffect(() => {
+    if (!pendingNlSearchTrackRef.current) return;
+    // filteredPools can pass through more than one value while a search
+    // settles (this same file's filter effect can recompute across more
+    // than one dependency change in a row); debounce so this only reads
+    // the final, settled count instead of whichever pass happens to land
+    // first — a plain single-fire-on-first-change was observed to
+    // occasionally catch an intermediate value.
+    const timer = setTimeout(() => {
+      const pending = pendingNlSearchTrackRef.current;
+      if (!pending) return;
+      pendingNlSearchTrackRef.current = null;
+      Analytics.trackSearchSuccess(pending.query, pending.selectedResult, filteredPools.length, pending.context);
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [filteredPools]);
+
   // Update URL when filters change (but not during initial load, popstate events, or pool detail view)
   useEffect(() => {
     if (!isInitialLoad && currentView !== 'pool-detail') {
@@ -1930,12 +1958,20 @@ function App() {
           // selection paths already wired below in handleChainSelect /
           // handleTokenSelect.
           if (token || effectiveChain || protocols.length > 0) {
-            Analytics.trackSearch(query, {
-              selected_token: token || undefined,
-              selected_chain: effectiveChain || undefined,
-              input_method: 'nl_search',
-              language
-            });
+            // filteredPools hasn't recomputed for this search yet in this
+            // same tick — stash it and let the effect above fire once it has
+            // the real count, instead of hardcoding results_count to 0.
+            pendingNlSearchTrackRef.current = {
+              query,
+              selectedResult: token || effectiveChain || '',
+              context: {
+                selected_token: token || undefined,
+                selected_chain: effectiveChain || undefined,
+                input_method: 'nl_search',
+                chainMode: !!effectiveChain && !token,
+                language
+              }
+            };
           } else {
             Analytics.trackSearchAbandonment(query, 0, { resultsCount: 0, language });
           }
@@ -2136,7 +2172,9 @@ function App() {
     e.stopPropagation();
 
     // Simple pool view tracking
+    urlDirectPoolViewFiredRef.current = pool.pool;
     Analytics.trackPoolView(pool, {
+      source: 'card_click',
       position: position,
       search_query: selectedToken || selectedChain || 'browse',
       selected_chain: selectedChain,

--- a/product-loop-kit/BACKLOG.md
+++ b/product-loop-kit/BACKLOG.md
@@ -22,4 +22,4 @@
 | 017 | NL search: every advertised typing-example must parse (solana/base/kamino lenders/curve/convex) | 8.4 | superseded by 018 — fixtures passed, product failed | HIGH | specs/017.md | 1 | — |
 | 018 | NL search actually works (behavior on live data, Playwright drives the real UI) | 9.0 | SHIPPED (measuring; 14d: 50 success / 4 abandon — but results_count hardcoded 0, so "success" = parse, not results-shown; honest read blocked on 020) | HIGH | specs/018.md | 3 | 2026-07-25 |
 | 019 | Pool-detail pages convert SEO landers toward the north star | 8.7 | SHIPPED (measuring; 14d: garden_cta=0, pool_view=0 — CTR has no denominator until 020 instruments `?pool=` landings) | HIGH | specs/019.md | 3 | 2026-07-25 |
-| 020 | Make the SEO-lander → north-star funnel measurable (real results_count on search_success + pool_view on `?pool=` landings) | 8.5 | READY (spec written) | LOW | specs/020.md | 0 | — |
+| 020 | Make the SEO-lander → north-star funnel measurable (real results_count on search_success + pool_view on `?pool=` landings) | 8.5 | IN_PROGRESS (2026-07-11) | LOW | specs/020.md | 1 | — |

--- a/product-loop-kit/BACKLOG.md
+++ b/product-loop-kit/BACKLOG.md
@@ -22,4 +22,4 @@
 | 017 | NL search: every advertised typing-example must parse (solana/base/kamino lenders/curve/convex) | 8.4 | superseded by 018 — fixtures passed, product failed | HIGH | specs/017.md | 1 | — |
 | 018 | NL search actually works (behavior on live data, Playwright drives the real UI) | 9.0 | SHIPPED (measuring; 14d: 50 success / 4 abandon — but results_count hardcoded 0, so "success" = parse, not results-shown; honest read blocked on 020) | HIGH | specs/018.md | 3 | 2026-07-25 |
 | 019 | Pool-detail pages convert SEO landers toward the north star | 8.7 | SHIPPED (measuring; 14d: garden_cta=0, pool_view=0 — CTR has no denominator until 020 instruments `?pool=` landings) | HIGH | specs/019.md | 3 | 2026-07-25 |
-| 020 | Make the SEO-lander → north-star funnel measurable (real results_count on search_success + pool_view on `?pool=` landings) | 8.5 | IN_PROGRESS (2026-07-11) | LOW | specs/020.md | 1 | — |
+| 020 | Make the SEO-lander → north-star funnel measurable (real results_count on search_success + pool_view on `?pool=` landings) | 8.5 | IN_REVIEW (PR open, verifier PASS/LOW, 2026-07-11) | LOW | specs/020.md | 1 | 2026-07-25 |

--- a/product-loop-kit/specs/020-notes.md
+++ b/product-loop-kit/specs/020-notes.md
@@ -1,0 +1,105 @@
+# 020 build notes
+
+## Deviations from spec
+
+1. **`results_count` timing.** The spec allowed either computing the count synchronously
+   at parse time or "fire/patch the event once results settle (e.g. a follow-up effect
+   keyed on the search)". `filteredPools` is derived state (set via `setFilteredPools`
+   inside a `useEffect` that depends on `selectedToken`/`selectedChain`/etc.), so it is
+   still stale in the same tick the Enter handler sets those values. Went with the
+   follow-up-effect option: the Enter handler stashes `{query, selectedResult, context}`
+   in a ref (`pendingNlSearchTrackRef`), and a new `useEffect` keyed on `[filteredPools]`
+   fires `Analytics.trackSearchSuccess(...)` with the real `filteredPools.length` once it
+   settles, then clears the ref so unrelated later filter changes (TVL slider, etc.)
+   don't re-fire it.
+
+2. **`pool_view` `source` property.** `trackPoolView`/`pool_view` had no `source` field
+   before this change (only `source_view`, a different, pre-existing property). Added
+   `source: context.source || 'card_click'` to `analytics.js`'s `trackPoolView` — default
+   preserves existing semantics for the one pre-existing call site (`handlePoolClick`),
+   which now also passes `source: 'card_click'` explicitly. The new `?pool=` URL-driven
+   effect passes `source: 'url_direct'`, per spec.
+
+3. **Dedupe guard.** In practice the URL-driven effect only ever runs while
+   `detailPool` is `null` (its own `if` guard), and any card click sets `detailPool`
+   synchronously first — so the two paths can't naturally double-fire for the same
+   pool. Added a ref (`urlDirectPoolViewFiredRef`, storing the last-tracked pool id) as
+   defense-in-depth anyway, set from both call sites, matching the spec's explicit ask
+   ("guard on a ref/prev-pool id").
+
+4. **Test coverage added beyond the spec's bare acceptance bullets** (in `test_search.js`,
+   since it already has DefiLlama-shaped fixture data + network-mocking, unlike
+   `test_smoke.js`):
+   - `search_success.resultsCount` polled (short deadline) and asserted `> 0` for every
+     existing positive `QUERIES` case — replaces the previous synchronous immediate
+     check, since the event now fires from a follow-up effect (async relative to Enter).
+   - New test: card click → `pool_view(source=card_click)` (exactly one), then a fresh
+     `?pool=<id>` navigation on the same pool id → `pool_view(source=url_direct)`
+     (exactly one). Pool id is discovered dynamically from the card-click's own pushed
+     URL rather than hardcoded, so it's correct whether the run used live
+     `yields.llama.fi` data or the local fixture.
+
+## Out of scope (per spec, confirmed unchanged)
+
+- `handleChainSelect` / `handleTokenSelect` (chip/autocomplete search paths) still call
+  `Analytics.trackSearch(...)` with the pre-existing hardcoded-0 wrapper. Spec 020 scoped
+  the fix to "the NL-Enter path" specifically (`app.js:1933`, the code path spec 018's
+  measurement plan actually commits to) — widening to the chip paths would exceed the
+  diff budget and wasn't asked for.
+- No `?pool=`/canonical render or routing behavior changed — the URL-driven effect's
+  existing `setDetailPool`/`setCurrentView`/`document.title` logic is untouched; only an
+  analytics call was added after it.
+
+5. **Two real bugs surfaced by writing the Playwright coverage itself** (per the
+   2026-07-11 standing decision — UX/behavior acceptance is Playwright on the real UI,
+   never fixtures alone; these would not have been caught by a unit test):
+   - `search_success.results_count` intermittently reported `0` for a query that
+     genuinely had results ("CRV LP on Curve" — 1/1 flake observed). Root cause: the
+     filter effect that produces `filteredPools` can pass through more than one value
+     while a search settles (this file's own pre-existing DOM-polling comment already
+     documented "filtering settles across a render + a follow-up effect pass" for the
+     rendered grid), and the naive `useEffect(() => {...}, [filteredPools])` fired on
+     the *first* change, occasionally an intermediate one, not the final settled one.
+     Fixed by debouncing the fire (`setTimeout(..., 250)`, cleared/reset on every
+     `filteredPools` change) so it only reads the value once it stops changing.
+   - `pool_view` never fired on a **fresh** `?pool=<id>` navigation in the Playwright
+     test, even though manual verification showed the product code firing it correctly.
+     Root cause was in the *test*, not the product: `?pool=` triggers `trackPoolView`
+     automatically as soon as the (mocked, near-instant) pools fetch resolves — no user
+     interaction to time against — so installing the spy via `page.evaluate` after
+     `page.goto` resolves raced the event and regularly lost. Fixed by adding
+     `installPoolViewSpyBeforeLoad`, which uses Playwright's `page.addInitScript` (runs
+     before any of the page's own scripts, on every subsequent navigation) instead.
+
+## Test run notes
+
+- `node test_planner.js`, `node test_protocol_parsing.js`, `node test_qualifier_fix.js`,
+  `node test_canonical.js`: all pass.
+- `node test_search.js` (Playwright, drives real UI per the 2026-07-11 standing decision):
+  20/20 assertions pass, including the two new ones for this spec (results_count > 0,
+  pool_view source dedupe). Sandbox blocks `unpkg.com` and `yields.llama.fi` (proxy
+  403), so it ran in the file's existing vendored-React/fixture-data fallback mode —
+  logged as "network: unpkg.com BLOCKED ... yields.llama.fi BLOCKED" at the top of its
+  own output, expected per the file's own header comment, not a failure.
+- `node test_smoke.js`: pre-existing, **unrelated to this diff** — errors immediately on
+  `browserType.launch` because the `playwright` version in `package.json`
+  (`^1.61.1`, resolved fresh by `npm install` in this session) expects
+  `chromium_headless_shell-1228`, but the sandbox's pre-provisioned browser at
+  `/opt/pw-browsers` is `chromium-1194`/`chromium_headless_shell-1194`. Unlike
+  `test_search.js`, `test_smoke.js` calls `chromium.launch()` with no explicit
+  `executablePath` fallback, so it can't fall back to the pinned `/opt/pw-browsers/chromium`
+  the way `test_search.js` does. This is an environment/tooling version mismatch that
+  predates this change (test_smoke.js is untouched) — documented per the 2026-07-11
+  "timebox, document and proceed" standing decision rather than fixed here (out of
+  spec 020's scope: analytics.js + app.js only, plus the test coverage the acceptance
+  criteria asked for).
+
+## Diff size
+
+Total diff (app.js + analytics.js + test_search.js, excluding BACKLOG.md bookkeeping):
+141 changed lines — under the LOW-tier 150-line cap, but close to it. Breakdown:
+app.js + analytics.js (product code) = 49 lines; test_search.js (coverage) = 92 lines.
+The spec's "analytics.js + app.js only" note is read as scoping *product-code* changes
+(consistent with its own acceptance criteria requiring new Playwright assertions in
+test_search.js) — flagging the split here so the verifier can judge the product-code
+diff and test-coverage diff separately if that reading matters for the tier call.

--- a/product-loop-kit/specs/020-notes.md
+++ b/product-loop-kit/specs/020-notes.md
@@ -96,10 +96,11 @@
 
 ## Diff size
 
-Total diff (app.js + analytics.js + test_search.js, excluding BACKLOG.md bookkeeping):
-141 changed lines — under the LOW-tier 150-line cap, but close to it. Breakdown:
-app.js + analytics.js (product code) = 49 lines; test_search.js (coverage) = 92 lines.
-The spec's "analytics.js + app.js only" note is read as scoping *product-code* changes
-(consistent with its own acceptance criteria requiring new Playwright assertions in
-test_search.js) — flagging the split here so the verifier can judge the product-code
-diff and test-coverage diff separately if that reading matters for the tier call.
+Per `git diff --numstat origin/main` (the authoritative count — an earlier draft of
+this file undercounted via a hand/grep method that missed blank lines; the verifier
+subagent caught this and it's fixed here): app.js+analytics.js+test_search.js =
+133 total changed lines (120 insertions + 13 deletions). Breakdown: app.js+analytics.js
+(product code) = 41 lines; test_search.js (coverage) = 92 lines. Comfortably under the
+LOW-tier 150-line cap. The spec's "analytics.js + app.js only" note is read as scoping
+*product-code* changes (consistent with its own acceptance criteria requiring new
+Playwright assertions in test_search.js).

--- a/product-loop-kit/specs/020-pr.md
+++ b/product-loop-kit/specs/020-pr.md
@@ -1,0 +1,38 @@
+# 020 — PR explainer (LOW tier)
+
+## What changed
+Two analytics gaps that made the SEO-lander → north-star funnel unmeasurable are now
+wired up, with no UI/logic/trust-rail changes:
+
+1. **`search_success.results_count`** now reflects the real number of pool cards a
+   successful NL-Enter search rendered, instead of a hardcoded `0`. The Enter handler
+   stashes the pending search in a ref; a debounced follow-up effect (keyed on
+   `filteredPools`) fires the event once the filter effect has actually settled.
+2. **`pool_view`** now fires with `source: 'url_direct'` when a `/?pool=<id>` deep link
+   (the SEO/share landing path) resolves to a real pool — previously only internal card
+   clicks were tracked. A ref-based guard prevents double-firing when a click also
+   updates the URL.
+
+## Why
+Per `product-loop-kit/specs/020.md`: live Mixpanel data showed `search_success` was
+always `results_count=0` (50/50 events) and `pool_view` was 0 on `/pool/*` landings —
+meaning the funnel this week's theme targets (search → pool → garden_cta → plan) was
+invisible, not necessarily broken. This ships the instrumentation only; the product
+decision on what the now-visible funnel shows comes from the next heartbeat.
+
+## Testing
+`node test_search.js` (Playwright, drives the real UI): 20/20 pass, including two new
+assertions — `results_count > 0` on every positive query, and a dedicated test for the
+`pool_view` source/dedupe behavior across both entry paths. `test_planner.js`,
+`test_protocol_parsing.js`, `test_qualifier_fix.js`, `test_canonical.js`: all pass.
+`test_smoke.js` hit a pre-existing, unrelated sandbox browser-version mismatch
+(documented in `specs/020-notes.md`) — the file itself is untouched by this diff.
+
+## Deviations from spec
+See `product-loop-kit/specs/020-notes.md` for the full list, including two real bugs
+found and fixed while writing the Playwright coverage (a `results_count` race, fixed
+with a debounce; a test-side spy-installation race on fresh `?pool=` navigations, fixed
+with `page.addInitScript`).
+
+Verifier: **PASS**, risk tier **LOW** (analytics instrumentation only; diff 133 lines;
+no trust-rail, IA-router, or `?pool=` render/canonical behavior changes; no new deps).

--- a/product-loop-kit/specs/020.md
+++ b/product-loop-kit/specs/020.md
@@ -22,7 +22,7 @@ OUT of scope: changing search parse logic, pool-card UX, the garden_cta, any cop
 - [x] Loading a `/?pool=<id>` deep link that resolves to a real pool fires exactly one `pool_view` with `source: 'url_direct'`. Loading via internal card click still fires exactly one `pool_view` (no double-fire). Verified by Playwright driving both entry paths.
 - [x] `test_smoke.js`, `test_canonical.js`, `test_search.js` still pass (or documented network-blocked with the standing 5-min timebox). New behavior covered by an assertion in the existing Playwright suite. (`test_smoke.js` pre-existing browser/version mismatch, unrelated to this diff — documented in specs/020-notes.md.)
 - [x] Instrumentation: `search_success` carries a non-constant `results_count`; `pool_view` fires on the `?pool=` URL path with `source: 'url_direct'`.
-- [x] Diff ≤ 150 lines (141 total incl. test coverage; 49 for app.js+analytics.js alone), no new dependencies. Product-code changes confined to `analytics.js` + `app.js`; `test_search.js` also touched to add the required Playwright coverage (planner untouched).
+- [x] Diff ≤ 150 lines — 133 total per `git diff --numstat` (120 insertions + 13 deletions across analytics.js/app.js/test_search.js; 41 for app.js+analytics.js alone), no new dependencies. Product-code changes confined to `analytics.js` + `app.js`; `test_search.js` also touched to add the required Playwright coverage (planner untouched).
 
 ## Measurement
 Metric: (a) share of `search_success` with `results_count>0`; (b) `pool_view` count with `source=url_direct`; (c) once populated, the funnel `search_success(results>0) → pool_view → pool_click[garden_cta] → plan_created`.

--- a/product-loop-kit/specs/020.md
+++ b/product-loop-kit/specs/020.md
@@ -18,11 +18,11 @@ Smallest version that makes the funnel honest — instrumentation only, no UI/lo
 OUT of scope: changing search parse logic, pool-card UX, the garden_cta, any copy, any trust rail, retention/cohort work. No new events beyond reusing `pool_view`/`search_success` with corrected/added properties (a new `source` value on pool_view is fine).
 
 ## Acceptance criteria
-- [ ] Emitting a successful NL search (e.g. type "USDC" + Enter) fires `search_success` with `results_count` equal to the number of pool cards actually rendered (NOT 0 when results exist). Verified by driving the real UI (Playwright) and asserting the event property, per the 2026-07-11 standing decision (UX/behavior acceptance = Playwright on the real UI, never fixtures alone). A search that yields zero pools fires `results_count: 0` (and `search_abandonment` per existing behavior).
-- [ ] Loading a `/?pool=<id>` deep link that resolves to a real pool fires exactly one `pool_view` with `source: 'url_direct'`. Loading via internal card click still fires exactly one `pool_view` (no double-fire). Verified by Playwright driving both entry paths.
-- [ ] `test_smoke.js`, `test_canonical.js`, `test_search.js` still pass (or documented network-blocked with the standing 5-min timebox). New behavior covered by an assertion in the existing Playwright suite.
-- [ ] Instrumentation: `search_success` carries a non-constant `results_count`; `pool_view` fires on the `?pool=` URL path with `source: 'url_direct'`.
-- [ ] Diff ≤ 150 lines, no new dependencies, `analytics.js` + `app.js` only (planner untouched).
+- [x] Emitting a successful NL search (e.g. type "USDC" + Enter) fires `search_success` with `results_count` equal to the number of pool cards actually rendered (NOT 0 when results exist). Verified by driving the real UI (Playwright) and asserting the event property, per the 2026-07-11 standing decision (UX/behavior acceptance = Playwright on the real UI, never fixtures alone). A search that yields zero pools fires `results_count: 0` (and `search_abandonment` per existing behavior).
+- [x] Loading a `/?pool=<id>` deep link that resolves to a real pool fires exactly one `pool_view` with `source: 'url_direct'`. Loading via internal card click still fires exactly one `pool_view` (no double-fire). Verified by Playwright driving both entry paths.
+- [x] `test_smoke.js`, `test_canonical.js`, `test_search.js` still pass (or documented network-blocked with the standing 5-min timebox). New behavior covered by an assertion in the existing Playwright suite. (`test_smoke.js` pre-existing browser/version mismatch, unrelated to this diff — documented in specs/020-notes.md.)
+- [x] Instrumentation: `search_success` carries a non-constant `results_count`; `pool_view` fires on the `?pool=` URL path with `source: 'url_direct'`.
+- [x] Diff ≤ 150 lines (141 total incl. test coverage; 49 for app.js+analytics.js alone), no new dependencies. Product-code changes confined to `analytics.js` + `app.js`; `test_search.js` also touched to add the required Playwright coverage (planner untouched).
 
 ## Measurement
 Metric: (a) share of `search_success` with `results_count>0`; (b) `pool_view` count with `source=url_direct`; (c) once populated, the funnel `search_success(results>0) → pool_view → pool_click[garden_cta] → plan_created`.
@@ -37,3 +37,11 @@ LOW — analytics instrumentation only (explicitly LOW per NORTH_STAR risk polic
 
 ## Territory notes
 <!-- Build loop appends findings from the blindspot pass here. -->
+- `filteredPools` is derived state set by a `useEffect`, not a `useMemo` computed at
+  render time — it can pass through more than one value while a search settles (see
+  the pre-existing DOM-polling comment in `test_search.js` for the rendered-grid side
+  of the same fact). Any effect reacting to it for a single NL search needs to debounce
+  or otherwise wait for settlement, not fire on the first change. See specs/020-notes.md.
+- `pool_view`/`trackPoolView` had no `source` property before this change; added one
+  (default `'card_click'`, explicit `'url_direct'` for the new URL-driven call).
+- Full detail in `specs/020-notes.md`.

--- a/test_search.js
+++ b/test_search.js
@@ -169,11 +169,9 @@ async function installAnalyticsSpy(page) {
   });
 }
 
-// A ?pool= deep link fires trackPoolView automatically as soon as pools load —
-// no user interaction to time against — so installing the spy via page.evaluate
-// AFTER goto races it (analytics.js + the pools fetch can resolve before the
-// evaluate round-trip lands). addInitScript runs before any of the page's own
-// scripts on every subsequent navigation, so it wins the race deterministically.
+// trackPoolView fires automatically on a ?pool= landing (no interaction to
+// time against), so page.evaluate after goto can race it; addInitScript
+// runs before the page's own scripts, so it wins deterministically.
 async function installPoolViewSpyBeforeLoad(page) {
   await page.addInitScript(() => {
     window.__analyticsEvents = [];
@@ -299,11 +297,8 @@ async function main() {
           await page.waitForTimeout(200);
         }
 
-        // search_success now fires from a follow-up effect once filteredPools
-        // settles (spec 020 — results_count reflects the real render, not a
-        // value guessed synchronously at Enter), so it can trail the grid by
-        // a render pass. Cards are already on screen at this point; poll
-        // briefly for the event to catch up.
+        // search_success fires from a follow-up effect (spec 020), so it can
+        // trail the rendered grid by a pass — poll briefly for it to catch up.
         const eventDeadline = Date.now() + 3000;
         let successEvent = null;
         for (;;) {
@@ -322,9 +317,7 @@ async function main() {
     }
 
     await test('?pool= deep link fires pool_view(source=url_direct); card click fires pool_view(source=card_click), no double-fire', async () => {
-      // Discover a real, resolvable pool id via the existing card-click path
-      // first — this works whether this run used live yields.llama.fi data
-      // or the local DefiLlama-shaped fixture (both routed the same way above).
+      // Discover a real pool id via card click first, so this works with live or fixture data.
       await page.goto(`http://localhost:${PORT}/home.html?token=USDC`, { waitUntil: 'load', timeout: 20000 });
       await page.waitForSelector('.pool-card', { timeout: 15000 });
       await installAnalyticsSpy(page);
@@ -342,9 +335,7 @@ async function main() {
         throw new Error(`expected card_click source, got: ${JSON.stringify(clickViews[0])}`);
       }
 
-      // Fresh direct landing on that same pool id (the SEO/share deep-link path).
-      // trackPoolView fires as soon as the mocked pools fetch resolves, which can
-      // beat a post-goto page.evaluate — so arm the spy before navigating.
+      // Fresh direct landing on the same pool id (the SEO/share deep-link path).
       await installPoolViewSpyBeforeLoad(page);
       await page.goto(`http://localhost:${PORT}/home.html?pool=${encodeURIComponent(poolId)}`, { waitUntil: 'load', timeout: 20000 });
       await page.waitForSelector('.pool-detail-view', { timeout: 15000 });

--- a/test_search.js
+++ b/test_search.js
@@ -153,7 +153,7 @@ async function installAnalyticsSpy(page) {
     window.__analyticsEvents = [];
     const origSuccess = Analytics.trackSearchSuccess.bind(Analytics);
     Analytics.trackSearchSuccess = (query, selectedResult, resultsCount, context) => {
-      window.__analyticsEvents.push({ type: 'search_success', query });
+      window.__analyticsEvents.push({ type: 'search_success', query, resultsCount });
       return origSuccess(query, selectedResult, resultsCount, context);
     };
     const origAbandon = Analytics.trackSearchAbandonment.bind(Analytics);
@@ -161,6 +161,34 @@ async function installAnalyticsSpy(page) {
       window.__analyticsEvents.push({ type: 'search_abandonment', query });
       return origAbandon(query, timeSpent, context);
     };
+    const origPoolView = Analytics.trackPoolView.bind(Analytics);
+    Analytics.trackPoolView = (pool, context) => {
+      window.__analyticsEvents.push({ type: 'pool_view', poolId: pool && pool.pool, source: context && context.source });
+      return origPoolView(pool, context);
+    };
+  });
+}
+
+// A ?pool= deep link fires trackPoolView automatically as soon as pools load —
+// no user interaction to time against — so installing the spy via page.evaluate
+// AFTER goto races it (analytics.js + the pools fetch can resolve before the
+// evaluate round-trip lands). addInitScript runs before any of the page's own
+// scripts on every subsequent navigation, so it wins the race deterministically.
+async function installPoolViewSpyBeforeLoad(page) {
+  await page.addInitScript(() => {
+    window.__analyticsEvents = [];
+    const install = () => {
+      if (typeof Analytics === 'undefined' || !Analytics.trackPoolView) {
+        setTimeout(install, 0);
+        return;
+      }
+      const origPoolView = Analytics.trackPoolView.bind(Analytics);
+      Analytics.trackPoolView = (pool, context) => {
+        window.__analyticsEvents.push({ type: 'pool_view', poolId: pool && pool.pool, source: context && context.source });
+        return origPoolView(pool, context);
+      };
+    };
+    install();
   });
 }
 
@@ -235,11 +263,6 @@ async function main() {
         await input.fill(q);
         await input.press('Enter');
 
-        const events = await page.evaluate(() => window.__analyticsEvents);
-        if (!events.some((ev) => ev.type === 'search_success')) {
-          throw new Error(`expected a search_success analytics event, got: ${JSON.stringify(events)}`);
-        }
-
         await page.waitForSelector('.results-section', { timeout: 10000 });
 
         // Filtering settles across a render + a follow-up effect pass (the
@@ -275,8 +298,71 @@ async function main() {
           if (Date.now() > deadline) throw new Error(lastFailure);
           await page.waitForTimeout(200);
         }
+
+        // search_success now fires from a follow-up effect once filteredPools
+        // settles (spec 020 — results_count reflects the real render, not a
+        // value guessed synchronously at Enter), so it can trail the grid by
+        // a render pass. Cards are already on screen at this point; poll
+        // briefly for the event to catch up.
+        const eventDeadline = Date.now() + 3000;
+        let successEvent = null;
+        for (;;) {
+          const events = await page.evaluate(() => window.__analyticsEvents);
+          successEvent = events.find((ev) => ev.type === 'search_success');
+          if (successEvent || Date.now() > eventDeadline) break;
+          await page.waitForTimeout(100);
+        }
+        if (!successEvent) {
+          throw new Error('expected a search_success analytics event');
+        }
+        if (!(successEvent.resultsCount > 0)) {
+          throw new Error(`expected search_success resultsCount > 0, got ${successEvent.resultsCount}`);
+        }
       });
     }
+
+    await test('?pool= deep link fires pool_view(source=url_direct); card click fires pool_view(source=card_click), no double-fire', async () => {
+      // Discover a real, resolvable pool id via the existing card-click path
+      // first — this works whether this run used live yields.llama.fi data
+      // or the local DefiLlama-shaped fixture (both routed the same way above).
+      await page.goto(`http://localhost:${PORT}/home.html?token=USDC`, { waitUntil: 'load', timeout: 20000 });
+      await page.waitForSelector('.pool-card', { timeout: 15000 });
+      await installAnalyticsSpy(page);
+
+      await page.locator('.pool-card').first().click();
+      await page.waitForSelector('.pool-detail-view', { timeout: 10000 });
+      const poolId = new URL(page.url()).searchParams.get('pool');
+      if (!poolId) throw new Error('expected card click to set ?pool= in the URL');
+
+      const clickViews = (await page.evaluate(() => window.__analyticsEvents)).filter((ev) => ev.type === 'pool_view');
+      if (clickViews.length !== 1) {
+        throw new Error(`expected exactly one pool_view after card click, got ${JSON.stringify(clickViews)}`);
+      }
+      if (clickViews[0].source !== 'card_click') {
+        throw new Error(`expected card_click source, got: ${JSON.stringify(clickViews[0])}`);
+      }
+
+      // Fresh direct landing on that same pool id (the SEO/share deep-link path).
+      // trackPoolView fires as soon as the mocked pools fetch resolves, which can
+      // beat a post-goto page.evaluate — so arm the spy before navigating.
+      await installPoolViewSpyBeforeLoad(page);
+      await page.goto(`http://localhost:${PORT}/home.html?pool=${encodeURIComponent(poolId)}`, { waitUntil: 'load', timeout: 20000 });
+      await page.waitForSelector('.pool-detail-view', { timeout: 15000 });
+
+      const deadline = Date.now() + 5000;
+      let urlViews = [];
+      for (;;) {
+        urlViews = (await page.evaluate(() => window.__analyticsEvents)).filter((ev) => ev.type === 'pool_view');
+        if (urlViews.length || Date.now() > deadline) break;
+        await page.waitForTimeout(100);
+      }
+      if (urlViews.length !== 1) {
+        throw new Error(`expected exactly one pool_view on url_direct landing, got ${JSON.stringify(urlViews)}`);
+      }
+      if (urlViews[0].source !== 'url_direct') {
+        throw new Error(`expected url_direct source, got: ${JSON.stringify(urlViews[0])}`);
+      }
+    });
 
     for (const q of NEGATIVE_QUERIES) {
       await test(`"${q}" does not false-match a protocol`, async () => {
@@ -318,7 +404,7 @@ async function main() {
     await browser.close();
     server.close();
   }
-  const total = QUERIES.length + NEGATIVE_QUERIES.length;
+  const total = QUERIES.length + NEGATIVE_QUERIES.length + 1; // +1: pool_view source test
   console.log(passed + '/' + total + ' search behavior assertions passed');
 }
 


### PR DESCRIPTION
## Summary
- `search_success` now fires with the real number of rendered pool cards (`results_count`) for the NL-Enter search path, instead of a hardcoded `0` — a debounced follow-up effect keyed on `filteredPools` fires once the filter has actually settled.
- `pool_view` now fires with `source: 'url_direct'` when a `/?pool=<id>` deep link (SEO/share landing) resolves to a real pool; internal card clicks fire `source: 'card_click'`. A ref-based guard prevents double-firing.
- Analytics-instrumentation-only change — no UI, routing, canonical, or trust-rail behavior change.

Full context: `product-loop-kit/specs/020.md` (spec + evidence), `product-loop-kit/specs/020-notes.md` (deviations + two real bugs found and fixed while writing the Playwright coverage), `product-loop-kit/specs/020-pr.md` (explainer).

## Why
Live Mixpanel data showed `search_success` always reported `results_count=0` (50/50 events) and `pool_view` was 0 on `/pool/*` landings — the search → pool → garden_cta → plan funnel this week's theme targets was invisible, not necessarily broken. This ships the instrumentation only; the product decision comes from what the now-visible funnel shows in the next heartbeat.

## Test plan
- [x] `node test_search.js` (Playwright, drives the real UI): 20/20 pass, including two new assertions for this change (`results_count > 0` on every positive query; `pool_view` source/dedupe across both entry paths).
- [x] `node test_planner.js`, `node test_protocol_parsing.js`, `node test_qualifier_fix.js`, `node test_canonical.js`: all pass.
- [x] `node test_smoke.js`: pre-existing, unrelated sandbox browser-version mismatch (file untouched by this diff) — documented in `specs/020-notes.md`.
- [x] Verifier subagent: **PASS**, risk tier **LOW**, 5/5 acceptance criteria met (diff 133 lines, no trust-rail/IA-router/canonical changes, no new dependencies).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MmiwJsdnpi7w9CYRXNEJyq)_