### PR TITLE
feat(015): fix apex/referral share URL in tweet flow (redirect hygiene)

### DIFF
--- a/planner.js
+++ b/planner.js
@@ -1589,7 +1589,7 @@
       });
       var tweetLabels = joinBundle(mixLabels2) || goalLabel(t, goal);
       var tweetText = t('shareTweet', tweetLabels);
-      var tweetUrl = 'https://defi.garden/referral=' + referralHandle;
+      var tweetUrl = 'https://www.defi.garden/?ref=' + encodeURIComponent(referralHandle);
       window.open(
         'https://twitter.com/intent/tweet?text=' + encodeURIComponent(tweetText) +
         '&url=' + encodeURIComponent(tweetUrl),

--- a/product-loop-kit/specs/015-notes.md
+++ b/product-loop-kit/specs/015-notes.md
@@ -1,0 +1,6 @@
+# 015 build notes
+
+- Single-line change at planner.js:1592 (`doWaitlistShare`), exactly per spec. No deviations.
+- Param name `ref` chosen over `referral` to match the existing convention in app.js:2144 (`url.searchParams.set('ref', 'defi.garden')`). Confirmed no decode-side reads `referral`/`ref` from the URL in planner.js, so no receiving-side change is needed.
+- Deliberately did NOT carry plan state in this share — spec scoped it out (005 owns plan-carrying shares); this is redirect hygiene only.
+- Verification: `node --check planner.js` clean; grep confirms bad apex/path pattern gone (0) and canonical `?ref=` pattern present (1); full 4-file test chain exits 0. planner.js is a browser script (window/React), so the tweet-URL string is verified by inspection + grep rather than a node unit test.

--- a/product-loop-kit/specs/015.md
+++ b/product-loop-kit/specs/015.md
@@ -1,0 +1,46 @@
+# Spec 015: Fix apex/referral share URL in the tweet flow (redirect hygiene)
+
+## Evidence
+`specs/010-diagnosis.md` (GSC "Page with redirect" = 534): the waitlist/subscription share builds its tweet URL by hand at `planner.js:1592`:
+```js
+var tweetUrl = 'https://defi.garden/referral=' + referralHandle;
+```
+Three defects in one line:
+1. **apex host** `defi.garden` → 301 redirects to `www.defi.garden` (the canonical host per canonical.js `SITE_ROOT`).
+2. **junk path** `/referral=<handle>` is a path segment, not a query param — it resolves to a non-existent route that redirects again, and carries no attribution the app can read.
+3. **unencoded** handle — a handle with URL-significant characters would break the link.
+
+Every shared tweet therefore points at a double-redirecting dead path, feeding the GSC redirect class and wasting the share.
+
+## Hypothesis
+Pointing the tweet URL at the canonical host with the referral as a real, encoded query param removes the redirect hop and the junk route — no behavior change for the user, cleaner share links, fewer redirect-class URLs for Google to chew on.
+
+## Change
+`planner.js` ONLY — replace the one line:
+```js
+var tweetUrl = 'https://www.defi.garden/?ref=' + encodeURIComponent(referralHandle);
+```
+- `www.defi.garden` + `https` → no apex→www / http→https hop (matches canonical.js `SITE_ROOT`).
+- `?ref=<handle>` proper query param (matches the existing `ref` convention already used in app.js:2144) instead of the junk `/referral=` path.
+- `encodeURIComponent` on the handle.
+
+OUT of scope: carrying full plan state in this share (the "Share my garden" hub, item 005, owns plan-carrying shares); the receiving side does not decode `ref` today — this is attribution/hygiene only, no new read path.
+
+## Acceptance criteria
+- [ ] `planner.js:~1592` builds `https://www.defi.garden/?ref=<encodeURIComponent(referralHandle)>`; the apex `defi.garden/referral=` pattern is gone (grep-verifiable)
+- [ ] `node --check planner.js` clean; the tweet URL passed to `twitter.com/intent/tweet?...&url=` is a single-hop canonical-host URL
+- [ ] Diff is `planner.js` only (one line); no other file touched
+- [ ] `node test_planner.js && node test_protocol_parsing.js && node test_qualifier_fix.js && node test_canonical.js` exit 0
+
+## Measurement
+GSC "Page with redirect" trend (partial — this fixes the tweet-URL contributor, not apex→www redirects at large); 2-6 week GSC validation. No same-week proxy — do not fake one.
+
+## Risk tier (builder's guess — verifier assigns independently)
+LOW — one-line redirect-hygiene fix, no new deps, no render-path or trust-rail change.
+
+## Open questions
+None blocking.
+
+## Territory notes
+- canonical.js `SITE_ROOT = 'https://www.defi.garden/'` is the canonical host; keep the tweet URL consistent with it.
+- The handle (`referralHandle`) is set from the Formspree `derived` handle after waitlist submit; it is not read back from the URL anywhere, so `ref` naming is free of decode-side coupling.


### PR DESCRIPTION
Ships backlog item 015 per `product-loop-kit/specs/015.md` (evidence: `specs/010-diagnosis.md`, GSC "Page with redirect").

**Fix** — `planner.js` `doWaitlistShare`, one line:
```diff
- var tweetUrl = 'https://defi.garden/referral=' + referralHandle;
+ var tweetUrl = 'https://www.defi.garden/?ref=' + encodeURIComponent(referralHandle);
```
Removes three defects in the shared tweet URL: apex host (`defi.garden` → 301 to www), junk path (`/referral=<handle>` → non-existent route, second redirect), and an unencoded handle. Now a single-hop canonical-host URL with the referral as a proper `?ref=` query param (matching the existing convention in `app.js:2144`).

Out of scope: plan-carrying shares (item 005 owns those); the receiving side does not decode `ref` — attribution/hygiene only.

**Verification** — verifier subagent: **PASS, risk LOW** (no trust rails, router, param-read path, config, or deps touched). `node --check planner.js` clean; bad pattern gone (grep 0), new pattern present (grep 1); test chain `test_planner.js` (190) / `test_protocol_parsing.js` / `test_qualifier_fix.js` / `test_canonical.js` (24) all exit 0. Diff: planner.js (1 line) + spec/notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_