### PR TITLE
feat(014): static token landing pages generator, top-100 by TVL (phase 1)

### DIFF
--- a/generate-token-pages.js
+++ b/generate-token-pages.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+/**
+ * Static Token Landing Page Generator for DeFi Garden (backlog 014, phase 1)
+ * Generates tokens/<slug>.html for the top-N tokens by TVL — real,
+ * server-delivered title/description/canonical/content, so crawlers see a
+ * genuine page instead of the JS shell that every ?token= URL renders before
+ * its DefiLlama fetch completes (specs/010-diagnosis.md, "Crawled — currently
+ * not indexed").
+ *
+ * TRUST PRINCIPLE (mirrors generate-sitemap.js / planner.js exactly): every
+ * number is computed at generation time from live DefiLlama pool data passed
+ * through the SAME sanity rails as the app. Anomalous pools (total APY >
+ * APY_SANITY_LIMIT) may NEVER be displayed or counted. Honest numbers, no hype.
+ *
+ * Phase 1 ships the mechanism + verified sample output only. It does NOT wire
+ * pages into the sitemap, vercel.json, or internal links — that (and the
+ * canonical-consolidation decision vs the ?token= app URLs) is phase 2, after
+ * a networked run produces real pages a human can review. See specs/014.md.
+ *
+ * Usage:
+ *   node generate-token-pages.js                 # fetch live API, write tokens/
+ *   node generate-token-pages.js --fixture f.json  # offline: read pools from disk
+ *   node generate-token-pages.js --limit 100 --out tokens
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+// Canonical site URL — matches plan.html / home.html / generate-stories.js
+const SITE_URL = 'https://www.defi.garden';
+const YIELDS_API = 'https://yields.llama.fi/pools';
+
+// --- Sanity rails & quality gate -------------------------------------------
+// Must stay in sync with app.js: DEFAULT_MIN_TVL (app.js:730) and
+// APY_SANITY_LIMIT (app.js:729), and with generate-sitemap.js's gate (013).
+// No shared import exists between these scripts.
+const DEFAULT_MIN_TVL = 10000000; // $10M floor
+const APY_SANITY_LIMIT = 1000;    // total APY above this may NEVER be shown
+const MIN_QUALIFYING_POOLS = 2;   // a token needs >=2 qualifying pools to earn a page
+const DEFAULT_LIMIT = 100;        // phase 1: top 100 tokens by TVL
+const POOLS_PER_PAGE = 8;         // how many pools to list on each page
+
+// Token symbol validity — mirrors generate-sitemap.js isValidToken.
+const TOKEN_REGEX = /^[A-Z0-9][A-Z0-9.\-_]{1,14}$/i;
+
+function poolTotalApy(pool) {
+  return (pool.apyBase || 0) + (pool.apyReward || 0);
+}
+function isAnomalousApy(pool) {
+  return poolTotalApy(pool) > APY_SANITY_LIMIT;
+}
+function isQualifyingPool(pool) {
+  return (pool.tvlUsd || 0) >= DEFAULT_MIN_TVL && !isAnomalousApy(pool);
+}
+function isValidToken(symbol) {
+  if (!symbol) return false;
+  return TOKEN_REGEX.test(symbol);
+}
+function tokenSymbols(pool) {
+  return (pool.symbol ? String(pool.symbol).split(/[-_\/\s]/) : [])
+    .map(s => s.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+// --- en-US formatting helpers (mirror app.js formatUsd/formatApy) ----------
+function formatUsd(n) {
+  const v = Number(n) || 0;
+  if (v >= 1e9) return '$' + (v / 1e9).toLocaleString('en-US', { maximumFractionDigits: 2 }) + 'B';
+  if (v >= 1e6) return '$' + (v / 1e6).toLocaleString('en-US', { maximumFractionDigits: 2 }) + 'M';
+  if (v >= 1e3) return '$' + (v / 1e3).toLocaleString('en-US', { maximumFractionDigits: 1 }) + 'K';
+  return '$' + v.toLocaleString('en-US', { maximumFractionDigits: 0 });
+}
+function formatApy(pct) {
+  return (Number(pct) || 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + '%';
+}
+function escapeHtml(str) {
+  return String(str == null ? '' : str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// URL/filesystem-safe slug for a token symbol.
+function tokenSlug(symbol) {
+  return String(symbol).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Aggregate pools into ranked token records.
+ * Returns [{ symbol, slug, totalTvl, qualifyingCount, pools:[...] }] sorted by
+ * totalTvl desc, filtered to tokens with >= MIN_QUALIFYING_POOLS, capped at limit.
+ * Anomalous pools never count toward the gate and never enter `pools`.
+ */
+function rankTopTokens(pools, limit) {
+  const cap = limit || DEFAULT_LIMIT;
+  const byToken = new Map(); // symbol -> { totalTvl, qualifyingCount, pools:[] }
+
+  pools.forEach(p => {
+    if (isAnomalousApy(p)) return;            // trust rail: never display/count anomalies
+    if ((p.tvlUsd || 0) < DEFAULT_MIN_TVL) return; // qualifying pools only
+    tokenSymbols(p).forEach(sym => {
+      if (!isValidToken(sym)) return;
+      if (!byToken.has(sym)) byToken.set(sym, { totalTvl: 0, qualifyingCount: 0, pools: [] });
+      const rec = byToken.get(sym);
+      rec.totalTvl += (p.tvlUsd || 0);
+      rec.qualifyingCount += 1;
+      rec.pools.push(p);
+    });
+  });
+
+  const records = [];
+  byToken.forEach((rec, symbol) => {
+    if (rec.qualifyingCount < MIN_QUALIFYING_POOLS) return; // 013 gate: skip thin tokens
+    rec.pools.sort((a, b) => (b.tvlUsd || 0) - (a.tvlUsd || 0));
+    records.push({
+      symbol,
+      slug: tokenSlug(symbol),
+      totalTvl: rec.totalTvl,
+      qualifyingCount: rec.qualifyingCount,
+      pools: rec.pools.slice(0, POOLS_PER_PAGE)
+    });
+  });
+
+  records.sort((a, b) => b.totalTvl - a.totalTvl);
+  return records.slice(0, cap);
+}
+
+/** Render a single token's static landing page as an HTML string. */
+function renderTokenPage(rec) {
+  const sym = escapeHtml(rec.symbol);
+  const pageUrl = `${SITE_URL}/tokens/${rec.slug}`;
+  const appUrl = `${SITE_URL}/?token=${encodeURIComponent(rec.symbol)}`;
+  const bestApy = Math.max(...rec.pools.map(poolTotalApy));
+  const title = `${sym} DeFi Yields — Live Pools by TVL | DeFi Garden 🌱`;
+  const description =
+    `${rec.qualifyingCount} live ${sym} pools above the $10M TVL floor, up to ` +
+    `${formatApy(bestApy)} APY, across ${new Set(rec.pools.map(p => p.chain)).size} chains. ` +
+    `Honest yields from DefiLlama data — no anomalous rates.`;
+
+  const rows = rec.pools.map(p => `        <tr>
+          <td>${escapeHtml(p.project || '—')}</td>
+          <td>${escapeHtml(p.chain || '—')}</td>
+          <td class="num">${formatApy(poolTotalApy(p))}</td>
+          <td class="num">${formatUsd(p.tvlUsd)}</td>
+        </tr>`).join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${escapeHtml(title)}</title>
+    <meta name="description" content="${escapeHtml(description)}">
+    <link rel="canonical" href="${pageUrl}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="${escapeHtml(title)}">
+    <meta property="og:description" content="${escapeHtml(description)}">
+    <meta property="og:url" content="${pageUrl}">
+    <meta property="og:image" content="${SITE_URL}/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="robots" content="index,follow">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🌱</text></svg>">
+    <style>
+      :root { color-scheme: light dark; }
+      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 820px; margin: 0 auto; padding: 24px; line-height: 1.6; }
+      h1 { font-size: 1.6rem; margin-bottom: 4px; }
+      .sub { color: #64748b; margin-top: 0; }
+      table { width: 100%; border-collapse: collapse; margin: 20px 0; }
+      th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #e2e8f0; }
+      td.num, th.num { text-align: right; }
+      .cta { display: inline-block; margin: 12px 0 24px; padding: 12px 20px; border: 1px solid #3b82f6; border-radius: 10px; color: #3b82f6; text-decoration: none; font-weight: 600; }
+      .note { color: #64748b; font-size: 0.9rem; }
+      .scroll { overflow-x: auto; }
+    </style>
+</head>
+<body>
+    <h1>${sym} DeFi Yields</h1>
+    <p class="sub">${escapeHtml(String(rec.qualifyingCount))} live pools above the $10M TVL floor · ranked by TVL</p>
+    <a class="cta" href="${appUrl}">See live ${sym} pools &rarr;</a>
+    <div class="scroll">
+    <table>
+      <thead>
+        <tr><th>Protocol</th><th>Chain</th><th class="num">APY</th><th class="num">TVL</th></tr>
+      </thead>
+      <tbody>
+${rows}
+      </tbody>
+    </table>
+    </div>
+    <p class="note">Yields are live from DefiLlama and pass DeFi Garden's trust filters (≥ $10M TVL, anomalous rates excluded). Not financial advice — education only.</p>
+    <p class="note"><a href="${SITE_URL}/">DeFi Garden 🌱</a> — plan your DeFi savings by goal.</p>
+</body>
+</html>
+`;
+}
+
+// --- IO layer (only runs as a script) --------------------------------------
+function fetchPoolData() {
+  return new Promise((resolve, reject) => {
+    https.get(YIELDS_API, (res) => {
+      let data = '';
+      res.on('data', (c) => { data += c; });
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data);
+          resolve(json.data || json);
+        } catch (e) { reject(new Error('parse failed: ' + e.message)); }
+      });
+    }).on('error', (e) => reject(new Error('API request failed: ' + e.message)));
+  });
+}
+
+function parseArgs(argv) {
+  const args = { fixture: process.env.POOLS_FIXTURE || null, out: 'tokens', limit: DEFAULT_LIMIT };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--fixture') args.fixture = argv[++i];
+    else if (argv[i] === '--out') args.out = argv[++i];
+    else if (argv[i] === '--limit') args.limit = parseInt(argv[++i], 10) || DEFAULT_LIMIT;
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  let pools;
+  if (args.fixture) {
+    console.log('📄 Loading pools from fixture:', args.fixture);
+    const raw = JSON.parse(fs.readFileSync(args.fixture, 'utf8'));
+    pools = raw.data || raw;
+  } else {
+    console.log('📡 Fetching pools from DefiLlama...');
+    pools = await fetchPoolData();
+  }
+  console.log(`✅ ${pools.length} pools`);
+
+  const ranked = rankTopTokens(pools, args.limit);
+  console.log(`🏆 Top ${ranked.length} tokens by TVL (>= ${MIN_QUALIFYING_POOLS} qualifying pools each)`);
+
+  const outDir = path.resolve(args.out);
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+  ranked.forEach(rec => {
+    fs.writeFileSync(path.join(outDir, `${rec.slug}.html`), renderTokenPage(rec));
+  });
+  console.log(`📝 Wrote ${ranked.length} pages to ${args.out}/`);
+}
+
+if (require.main === module) {
+  main().catch(e => { console.error('❌', e.message); process.exit(1); });
+}
+
+module.exports = {
+  rankTopTokens, renderTokenPage, tokenSlug, isQualifyingPool, isAnomalousApy,
+  isValidToken, poolTotalApy, formatUsd, formatApy,
+  DEFAULT_MIN_TVL, APY_SANITY_LIMIT, MIN_QUALIFYING_POOLS, DEFAULT_LIMIT, SITE_URL
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "serve": "npx --yes http-server -p 8000 -c-1",
     "dev": "npx --yes http-server -p 8000 -c-1",
     "generate:llms": "node generate-llms.js",
-    "test": "node test_planner.js && node test_protocol_parsing.js && node test_qualifier_fix.js && node test_smoke.js && node test_canonical.js && node test_search.js"
+    "tokens": "node generate-token-pages.js",
+    "test": "node test_planner.js && node test_protocol_parsing.js && node test_qualifier_fix.js && node test_smoke.js && node test_canonical.js && node test_search.js && node test_token_pages.js"
   },
   "keywords": [
     "defi",

--- a/product-loop-kit/specs/014-notes.md
+++ b/product-loop-kit/specs/014-notes.md
@@ -1,0 +1,19 @@
+# 014 build notes (phase 1)
+
+## What shipped
+- `generate-token-pages.js` — Node generator mirroring `generate-stories.js`/`generate-sitemap.js` (no build step, no new deps). Ranks tokens by aggregate qualifying TVL, applies 013's ≥2-qualifying-pool gate, emits self-canonical static `tokens/<slug>.html` with server-delivered title/description/canonical/content + a `?token=` deep link.
+- `test_token_pages.js` + `test_fixtures/pools-sample.json` — 17 assertions on real emitted HTML, run offline. Added to `package.json` `test` chain; new `npm run tokens` script.
+- `product-loop-kit/specs/014-sample-aaa.html` — one sample page (from the mock fixture) committed for review.
+
+## Deviations / conservative choices
+- **Offline fixture path added** (`--fixture` / `POOLS_FIXTURE`). generate-stories.js just fails without network; 014 needs to be verifiable where `yields.llama.fi` is 403-blocked (this sandbox, same wall as 013/018). Real pages come from a networked run.
+- **Did NOT commit the generated `tokens/` prod output.** The only data available here is the mock fixture; shipping fake AAA/BBB pages to `tokens/` (Vercel would serve them at `/tokens/aaa`) would be junk in prod. Phase 2's networked run generates + commits the real 100 pages. One sample kept under `specs/` for review instead.
+- **No sitemap / vercel.json / home.html / app-canonical changes** — deliberately out of scope (spec). The pages aren't wired into the sitemap or internal links, so nothing enters the index until phase 2. This also sidesteps, for now, the canonical-consolidation question (`/tokens/<slug>` self-canonical vs the existing `?token=<SYMBOL>` self-canonical from 011) — flagged as the phase-2 human decision.
+- **Constants duplicated in-file** (`DEFAULT_MIN_TVL`, `APY_SANITY_LIMIT`) with "must stay in sync with app.js" comments — same pattern generate-sitemap.js already uses; no shared import exists between these scripts.
+- Pages use a minimal inline `<style>` (no gradients, no app design tokens) — matching the `stories/` precedent of standalone static pages with their own lightweight CSS, not the app's neumorphic component system (which governs the app UI, not static SEO landers).
+
+## Verification
+- `node --check generate-token-pages.js` clean.
+- `node test_token_pages.js` — 17/17 assertions pass (ranking desc, gate drops thin/sub-floor tokens, anomalous pool excluded from content AND gate, cap honored, slug safety, self-canonical, server-delivered title/description, app deep link, escaping).
+- Ran the generator against the fixture offline → 3 pages written correctly; `specs/014-sample-aaa.html` is the committed result.
+- Offline test chain (`test_planner`, `test_protocol_parsing`, `test_qualifier_fix`, `test_canonical`) exits 0. `test_smoke.js`/`test_search.js` in the npm chain need browser/live network and are not runnable in this sandbox (pre-existing limitation, not introduced here).

--- a/product-loop-kit/specs/014-pr.md
+++ b/product-loop-kit/specs/014-pr.md
@@ -1,0 +1,41 @@
+# 014 — PR explainer (HIGH tier): static token landing pages, top-100 by TVL (phase 1)
+
+## Goal
+Drain the biggest GSC failure class — **Crawled — currently not indexed = 22,877** (`specs/010-diagnosis.md`). Its cause: every `?token=X` URL serves one identical `home.html` JS shell; the real title/canonical/content only appear after client JS + a multi-MB DefiLlama fetch. Crawlers see 20k near-duplicate thin shells and skip them. Fix 014: give the highest-value tokens a **real static page** with server-delivered content.
+
+## Intuition
+The `stories/` pages already prove this codebase can pre-render honest, data-derived static pages at generation time. 014 applies the same trick to tokens: a Node script fetches pools, ranks the top 100 by TVL, and writes one `tokens/<slug>.html` per token whose HTML is complete before any JS runs — so a non-rendering crawl sees genuine content instead of the shell.
+
+## What changed, in reading order
+1. **`generate-token-pages.js`** (new) — mirrors `generate-stories.js`/`generate-sitemap.js` (no build step, no deps):
+   - `rankTopTokens(pools, limit)` — aggregates `tvlUsd` per valid token, applies the **013 quality gate** (≥2 pools at ≥$10M TVL, non-anomalous), ranks by aggregate qualifying TVL desc, caps at 100. Anomalous pools (>1000% total APY) `return` before aggregation, so they never enter a token's TVL, count, or pool list — the trust rail holds at the ranking layer, not just the display layer.
+   - `renderTokenPage(rec)` — emits a **self-canonical** page (`.../tokens/<slug>`), server-delivered `<title>`/`<meta description>`, a real pool table (protocol/chain/APY/TVL via en-US helpers), and one deep link into the live app at `?token=<SYMBOL>`.
+   - Pure functions exported under `require.main === module` (canonical.js pattern) for testing; an `--fixture` path loads pools from disk so the logic is runnable where `yields.llama.fi` is blocked.
+2. **`test_token_pages.js` + `test_fixtures/pools-sample.json`** — 17 assertions on the real emitted HTML: gate drops thin/sub-floor tokens, anomalous pools excluded from content AND gate, ranking desc, cap honored, slug safety, self-canonical, server-delivered title/description, app deep link, HTML escaping.
+3. **`package.json`** — `node test_token_pages.js` added to the `test` chain; new `npm run tokens` script.
+4. **`specs/014-sample-aaa.html`** — one sample page (from the mock fixture) for review.
+
+## Why phase 1 wires nothing
+The generated `tokens/` prod output is **not** committed (only the mock fixture is available here — shipping fake pages to prod would be junk), and no `sitemap-*.xml`/`vercel.json`/`home.html`/canonical change is made. So nothing enters Google's index yet. Phase 2 — a networked run that produces the real 100 pages a human can eyeball, plus the **canonical-consolidation decision** between the new `/tokens/<slug>` self-canonical and the existing `?token=<SYMBOL>` self-canonical (011) — is deliberately deferred to avoid self-competition on the sacred SEO surface.
+
+## Deviations from spec
+None material. Offline fixture path added (spec called for it). Verifier's two non-blocking notes: an unreachable double-escape of the symbol (TOKEN_REGEX forbids escapable chars, so harmless and over-safe — left as-is for a surgical diff) and `POOLS_PER_PAGE=8` truncating the table while the copy's count reflects all qualifying pools (honest).
+
+## Verification
+Verifier subagent (independent): **PASS, HIGH, 7/7** — including an adversarial fixture proving $5B anomalous pools don't inflate rank and leave no trace on the page, and boundary checks (exactly $10M + exactly 1000% qualifies; just over/under excluded). `test_token_pages.js` 17/17; offline chain (`test_planner` 190, `test_protocol_parsing`, `test_qualifier_fix`, `test_canonical` 24) exits 0.
+
+---
+
+## Quiz (answers base64 at the bottom)
+1. Why do the current `?token=X` URLs fail to get indexed?
+   A. They return HTTP 404  · B. They serve one identical JS shell; real content needs JS + an API fetch a crawler may not run  · C. They're blocked by robots.txt
+2. Where is an anomalous (>1000% APY) pool stopped?
+   A. Only hidden via CSS  · B. Only in the display template  · C. Before aggregation in `rankTopTokens`, so it never affects TVL, count, or the pool list
+3. What canonical does a generated token page declare?
+   A. The homepage `/`  · B. Itself, `https://www.defi.garden/tokens/<slug>`  · C. The `?token=` app URL
+4. Why doesn't phase 1 commit the `tokens/` pages or touch the sitemap?
+   A. Laziness  · B. It's forbidden forever  · C. Only mock data is reachable here; real pages + sitemap wiring + the canonical-consolidation call are phase 2 after a networked run
+5. What gate must a token clear to earn a page?
+   A. Any single pool  · B. ≥2 pools at ≥$10M TVL, non-anomalous (the 013 gate)  · C. Top APY
+
+<!-- answers: MTpCICAyOkMgIDM6QiAgNDpDICA1OkI= -->

--- a/product-loop-kit/specs/014-sample-aaa.html
+++ b/product-loop-kit/specs/014-sample-aaa.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AAA DeFi Yields — Live Pools by TVL | DeFi Garden 🌱</title>
+    <meta name="description" content="3 live AAA pools above the $10M TVL floor, up to 5.00% APY, across 3 chains. Honest yields from DefiLlama data — no anomalous rates.">
+    <link rel="canonical" href="https://www.defi.garden/tokens/aaa">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="AAA DeFi Yields — Live Pools by TVL | DeFi Garden 🌱">
+    <meta property="og:description" content="3 live AAA pools above the $10M TVL floor, up to 5.00% APY, across 3 chains. Honest yields from DefiLlama data — no anomalous rates.">
+    <meta property="og:url" content="https://www.defi.garden/tokens/aaa">
+    <meta property="og:image" content="https://www.defi.garden/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="robots" content="index,follow">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🌱</text></svg>">
+    <style>
+      :root { color-scheme: light dark; }
+      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 820px; margin: 0 auto; padding: 24px; line-height: 1.6; }
+      h1 { font-size: 1.6rem; margin-bottom: 4px; }
+      .sub { color: #64748b; margin-top: 0; }
+      table { width: 100%; border-collapse: collapse; margin: 20px 0; }
+      th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #e2e8f0; }
+      td.num, th.num { text-align: right; }
+      .cta { display: inline-block; margin: 12px 0 24px; padding: 12px 20px; border: 1px solid #3b82f6; border-radius: 10px; color: #3b82f6; text-decoration: none; font-weight: 600; }
+      .note { color: #64748b; font-size: 0.9rem; }
+      .scroll { overflow-x: auto; }
+    </style>
+</head>
+<body>
+    <h1>AAA DeFi Yields</h1>
+    <p class="sub">3 live pools above the $10M TVL floor · ranked by TVL</p>
+    <a class="cta" href="https://www.defi.garden/?token=AAA">See live AAA pools &rarr;</a>
+    <div class="scroll">
+    <table>
+      <thead>
+        <tr><th>Protocol</th><th>Chain</th><th class="num">APY</th><th class="num">TVL</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>aave-v3</td>
+          <td>Ethereum</td>
+          <td class="num">4.10%</td>
+          <td class="num">$500M</td>
+        </tr>
+        <tr>
+          <td>compound-v3</td>
+          <td>Base</td>
+          <td class="num">4.00%</td>
+          <td class="num">$300M</td>
+        </tr>
+        <tr>
+          <td>morpho</td>
+          <td>Arbitrum</td>
+          <td class="num">5.00%</td>
+          <td class="num">$120M</td>
+        </tr>
+      </tbody>
+    </table>
+    </div>
+    <p class="note">Yields are live from DefiLlama and pass DeFi Garden's trust filters (≥ $10M TVL, anomalous rates excluded). Not financial advice — education only.</p>
+    <p class="note"><a href="https://www.defi.garden/">DeFi Garden 🌱</a> — plan your DeFi savings by goal.</p>
+</body>
+</html>

--- a/product-loop-kit/specs/014.md
+++ b/product-loop-kit/specs/014.md
@@ -1,0 +1,45 @@
+# Spec 014: Static token landing pages, top-100 by TVL — phase 1
+
+## Evidence
+`specs/010-diagnosis.md`, the largest GSC class: **Crawled — currently not indexed = 22,877.** Mechanism: 20k+ near-identical thin JS shells (one `home.html` for every `?token=` URL; per-URL title/canonical/content only appear after client JS + a multi-MB DefiLlama fetch). To a crawler, each token URL is a low-value duplicate. Ranked fix 014: "Static token/chain landing pages for top-N by TVL via the generate-*.js pattern (stories/ precedent): real server-delivered title/canonical/content + link into the app. Phase 1: top 100." Gate cleared: this was gated behind 020 (measurability), which shipped (PR #104).
+
+## Hypothesis
+Serving a real, static, server-delivered HTML page (title/description/canonical/content all present without JS) for the top-100 tokens by TVL gives crawlers genuine content instead of a thin shell, draining the "Crawled — not indexed" class for those high-value tokens over the GSC validation window. Confidence: supported — this is the standard remediation for JS-shell SPAs, and the `stories/` pages already prove the pattern on this codebase.
+
+## Change
+New `generate-token-pages.js` (Node, mirrors `generate-stories.js` + `generate-sitemap.js` — no build step, no new deps):
+1. **Data**: fetch pools from `https://yields.llama.fi/pools` (same as the other generators). Support an offline fixture (`--fixture <path>` / `POOLS_FIXTURE` env) that loads pool JSON from disk instead of the network, so the generator's logic is runnable/verifiable where the live API is unreachable (this sandbox's egress policy blocks `yields.llama.fi` — same wall 013/018 hit).
+2. **Ranking + quality gate**: aggregate `tvlUsd` per valid token symbol; keep only tokens with **≥2 qualifying pools** (`tvlUsd ≥ DEFAULT_MIN_TVL $10M` AND not anomalous `APY_SANITY_LIMIT 1000%`) — the SAME gate 013 put on the sitemap, so a page is never emitted for a token whose live app view would be empty by default. Rank by aggregate qualifying TVL; take **top 100**.
+3. **Trust rails intact**: anomalous pools (total APY > 1000%) are EXCLUDED from a page's pool list and never counted toward its gate — never displayed, never hyped. `DEFAULT_MIN_TVL` floor applied. Constants kept in-file with "must stay in sync with app.js" comments, exactly like `generate-sitemap.js`.
+4. **Per page** `tokens/<slug>.html`:
+   - server-delivered `<title>`, `<meta name="description">`, and **self-canonical** `<link rel="canonical" href="https://www.defi.garden/tokens/<slug>">` — the static page is the real crawlable surface.
+   - real content rendered at generation time: the token's top qualifying pools (protocol, chain, APY, TVL) through the sanity rails, all money/numbers via en-US helpers.
+   - one prominent link INTO the live app at `https://www.defi.garden/?token=<SYMBOL>` ("See live pools →").
+   - honest framing, no APY hype; no `og`/number claims not derived from the fetched data.
+5. **Pure functions exported** (`rankTopTokens`, `renderTokenPage`, helpers) under a `require.main === module` guard (canonical.js pattern) so `test_token_pages.js` can assert on real emitted HTML.
+6. `test_token_pages.js` (test_planner.js assert style) runs the generator against a committed mock fixture and asserts: ranking is by TVL desc, the ≥2-qualifying-pool gate drops thin tokens, anomalous pools are excluded from content AND gate, each page has a self-canonical + server-delivered title + ≥1 real pool row + the `?token=` app link, and slugs are filesystem/URL-safe. Added to the `package.json` test chain.
+
+**OUT of scope this phase** (documented, deliberate): NO edits to `sitemap-*.xml`, `vercel.json`, `home.html`, or the app's canonical logic (011). Wiring these pages into the sitemap / internal links — and the canonical-consolidation decision between `/tokens/<slug>` and `?token=<SYMBOL>` — is phase 2, to be done AFTER a networked run produces real pages a human can eyeball (they are the sacred SEO surface). Phase 1 ships the mechanism + verified sample output only, so nothing enters the index until deliberately wired.
+
+## Acceptance criteria
+- [ ] `generate-token-pages.js` runs against the committed fixture (`--fixture`) with zero network and writes `tokens/*.html`; sample output committed for review
+- [ ] Ranking by aggregate qualifying TVL desc; only tokens with ≥2 qualifying pools emitted; capped at top 100 (assert on a fixture crafted to exercise each branch)
+- [ ] Anomalous pools (>1000% total APY) never appear in a page's pool list and never count toward its gate (trust rails); `DEFAULT_MIN_TVL` floor applied
+- [ ] Every emitted page has: self-canonical `https://www.defi.garden/tokens/<slug>`, server-delivered `<title>` + `<meta description>` (present in raw HTML, no JS), ≥1 real pool row, and a link to `https://www.defi.garden/?token=<SYMBOL>`
+- [ ] Slugs are URL/filesystem-safe; all numbers via en-US helpers
+- [ ] No changes to `sitemap-*.xml`, `vercel.json`, `home.html`, or app canonical logic
+- [ ] `node test_token_pages.js` + the full existing chain (`test_planner.js && test_protocol_parsing.js && test_qualifier_fix.js && test_canonical.js`) exit 0; every run timeboxed 5 min
+
+## Measurement
+GSC "Crawled — currently not indexed" trend for the top-100 token URLs post-wiring (phase 2); 2-6 week validation cycles. Phase 1 ships no live URLs, so no same-week metric — do not fake one.
+
+## Risk tier (builder's guess — verifier assigns independently)
+HIGH — generates SEO surface (even though phase 1 doesn't wire it, it's an SEO-facing generator and belongs to the sacred-surface class per NORTH_STAR).
+
+## Open questions
+None blocking phase 1. Phase 2 needs a human decision: canonical consolidation between the new static `/tokens/<slug>` pages and the existing `?token=<SYMBOL>` app URLs before both are indexable (avoid self-competition).
+
+## Territory notes
+- `generate-stories.js` is the closest precedent: fetchPoolData, escapeHtml, futureValue, formatUsd/formatApy/formatTvl, self-canonical page template — mirror it.
+- `generate-sitemap.js` already carries the 013 quality-gate constants + `isQualifyingPool`/`isAnomalousApy`/`isValidToken`/`getPoolType` — mirror the same logic and the "must stay in sync with app.js" comments (no shared import exists between scripts).
+- Live data is 403-blocked here; the fixture path is how phase 1 is verified offline. Real pages come from a networked run (CI or a human machine), same as 013's real sitemap counts.

--- a/test_fixtures/pools-sample.json
+++ b/test_fixtures/pools-sample.json
@@ -1,0 +1,15 @@
+[
+  { "symbol": "AAA", "project": "aave-v3", "chain": "Ethereum", "tvlUsd": 500000000, "apyBase": 4.1, "apyReward": 0 },
+  { "symbol": "AAA", "project": "compound-v3", "chain": "Base", "tvlUsd": 300000000, "apyBase": 3.8, "apyReward": 0.2 },
+  { "symbol": "AAA", "project": "morpho", "chain": "Arbitrum", "tvlUsd": 120000000, "apyBase": 5.0, "apyReward": 0 },
+  { "symbol": "BBB", "project": "curve", "chain": "Ethereum", "tvlUsd": 60000000, "apyBase": 6.2, "apyReward": 1.1 },
+  { "symbol": "BBB", "project": "convex", "chain": "Ethereum", "tvlUsd": 40000000, "apyBase": 7.0, "apyReward": 2.0 },
+  { "symbol": "CCC", "project": "aave-v3", "chain": "Polygon", "tvlUsd": 90000000, "apyBase": 3.0, "apyReward": 0 },
+  { "symbol": "CCC", "project": "tinypool", "chain": "Polygon", "tvlUsd": 500000, "apyBase": 9.0, "apyReward": 0 },
+  { "symbol": "DDD", "project": "smallcap", "chain": "Base", "tvlUsd": 2000000, "apyBase": 8.0, "apyReward": 0 },
+  { "symbol": "DDD", "project": "smallcap2", "chain": "Base", "tvlUsd": 3000000, "apyBase": 8.5, "apyReward": 0 },
+  { "symbol": "EEE", "project": "realpool", "chain": "Ethereum", "tvlUsd": 50000000, "apyBase": 6.0, "apyReward": 0 },
+  { "symbol": "EEE", "project": "degenfarm", "chain": "Solana", "tvlUsd": 80000000, "apyBase": 1500, "apyReward": 400 },
+  { "symbol": "USDC.E", "project": "aave-v3", "chain": "Arbitrum", "tvlUsd": 45000000, "apyBase": 4.5, "apyReward": 0 },
+  { "symbol": "USDC.E", "project": "stargate", "chain": "Optimism", "tvlUsd": 35000000, "apyBase": 5.1, "apyReward": 0.4 }
+]

--- a/test_token_pages.js
+++ b/test_token_pages.js
@@ -1,0 +1,101 @@
+/* Unit tests for the static token-page generator (spec 014, phase 1).
+   Runs the generator's pure functions against a crafted fixture and asserts
+   on the real emitted HTML. Run: node test_token_pages.js */
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const gen = require('./generate-token-pages.js');
+
+let passed = 0;
+function test(name, fn) {
+  try { fn(); passed++; console.log('  ✓ ' + name); }
+  catch (err) { console.error('  ✗ ' + name + '\n    ' + err.message); process.exitCode = 1; }
+}
+
+// Fixture crafted to exercise every branch. TVL in USD.
+// AAA: 3 qualifying pools, highest aggregate TVL  -> emitted, rank #1
+// BBB: 2 qualifying pools, lower aggregate TVL     -> emitted, rank #2
+// CCC: 1 qualifying pool                           -> dropped (gate < 2)
+// DDD: 2 pools but both below the $10M TVL floor   -> dropped
+// EEE: 2 pools where one is anomalous (>1000% APY) -> anomaly excluded, left with 1 -> dropped
+// USDC.E: dotted symbol, 2 qualifying pools        -> emitted, slug-safe
+const pools = JSON.parse(fs.readFileSync(path.join(__dirname, 'test_fixtures', 'pools-sample.json'), 'utf8'));
+const ranked = gen.rankTopTokens(pools, 100);
+const bySym = Object.fromEntries(ranked.map(r => [r.symbol, r]));
+
+console.log('rankTopTokens — gate + ranking + trust rails');
+test('emits exactly the tokens that clear the >=2 qualifying-pool gate', () => {
+  assert.deepStrictEqual(ranked.map(r => r.symbol).sort(), ['AAA', 'BBB', 'USDC.E']);
+});
+test('ranks by aggregate qualifying TVL desc (AAA before BBB)', () => {
+  const iA = ranked.findIndex(r => r.symbol === 'AAA');
+  const iB = ranked.findIndex(r => r.symbol === 'BBB');
+  assert.ok(iA < iB, 'AAA should rank above BBB');
+  assert.ok(bySym['AAA'].totalTvl > bySym['BBB'].totalTvl);
+});
+test('single-qualifying-pool token (CCC) is dropped', () => {
+  assert.ok(!bySym['CCC']);
+});
+test('sub-floor token (DDD) is dropped', () => {
+  assert.ok(!bySym['DDD']);
+});
+test('anomalous pool excluded from content AND gate (EEE dropped to <2)', () => {
+  assert.ok(!bySym['EEE'], 'EEE had 1 real + 1 anomalous pool, should not clear the gate');
+});
+test('no rendered pool anywhere is anomalous (>1000% total APY)', () => {
+  ranked.forEach(r => r.pools.forEach(p => {
+    assert.ok(gen.poolTotalApy(p) <= gen.APY_SANITY_LIMIT, r.symbol + ' has an anomalous pool');
+  }));
+});
+test('every rendered pool clears the $10M TVL floor', () => {
+  ranked.forEach(r => r.pools.forEach(p => {
+    assert.ok((p.tvlUsd || 0) >= gen.DEFAULT_MIN_TVL, r.symbol + ' has a sub-floor pool');
+  }));
+});
+test('cap is honored (limit=1 -> single top token AAA)', () => {
+  const top1 = gen.rankTopTokens(pools, 1);
+  assert.strictEqual(top1.length, 1);
+  assert.strictEqual(top1[0].symbol, 'AAA');
+});
+
+console.log('tokenSlug — URL/filesystem safety');
+test('dotted symbol slugs to safe form', () => {
+  assert.strictEqual(gen.tokenSlug('USDC.E'), 'usdc-e');
+  assert.strictEqual(bySym['USDC.E'].slug, 'usdc-e');
+});
+test('slug has no unsafe chars', () => {
+  ranked.forEach(r => assert.ok(/^[a-z0-9-]+$/.test(r.slug), 'bad slug: ' + r.slug));
+});
+
+console.log('renderTokenPage — server-delivered SEO content');
+const html = gen.renderTokenPage(bySym['AAA']);
+test('self-canonical to /tokens/<slug>', () => {
+  assert.ok(html.includes('<link rel="canonical" href="https://www.defi.garden/tokens/aaa">'), 'missing self-canonical');
+});
+test('server-delivered <title> present in raw HTML (no JS)', () => {
+  assert.ok(/<title>AAA DeFi Yields[^<]*<\/title>/.test(html), 'missing title');
+});
+test('server-delivered meta description present', () => {
+  assert.ok(/<meta name="description" content="[^"]+">/.test(html), 'missing description');
+});
+test('links into the live app at ?token=<SYMBOL>', () => {
+  assert.ok(html.includes('https://www.defi.garden/?token=AAA'), 'missing app deep link');
+});
+test('renders >=1 real pool row with en-US formatted numbers', () => {
+  assert.ok(/<td class="num">\d/.test(html), 'no formatted numeric cell');
+  assert.ok(html.includes('%'), 'no APY');
+  assert.ok(html.includes('$'), 'no TVL');
+});
+test('indexable (robots index,follow — these pages are meant to be found)', () => {
+  assert.ok(html.includes('content="index,follow"'), 'should be indexable');
+});
+test('HTML is escaped (no raw unescaped angle-brackets in content values)', () => {
+  // project names etc. go through escapeHtml; sanity-check the helper is wired
+  const evil = gen.renderTokenPage({ symbol: 'X<Y', slug: 'x-y', qualifyingCount: 2,
+    totalTvl: 2e7, pools: [{ project: '<script>', chain: 'Base', tvlUsd: 1e7, apyBase: 5, apyReward: 0 },
+                            { project: 'aave', chain: 'Base', tvlUsd: 1e7, apyBase: 4, apyReward: 0 }] });
+  assert.ok(!evil.includes('<script>'), 'unescaped project name leaked into HTML');
+  assert.ok(evil.includes('&lt;script&gt;'), 'expected escaped project name');
+});
+
+console.log(`\n${passed} assertions passed`);


### PR DESCRIPTION
Ships backlog item 014 phase 1 per `product-loop-kit/specs/014.md` (evidence: `specs/010-diagnosis.md`, the 22,877-URL "Crawled — currently not indexed" class).

## What
New **`generate-token-pages.js`** — a Node generator (mirrors `generate-stories.js`/`generate-sitemap.js`, no build step, no new deps) that ranks the top-100 tokens by aggregate TVL, applies 013's ≥2-qualifying-pool quality gate, and emits **self-canonical** static `tokens/<slug>.html` pages with server-delivered `<title>`/`<meta description>`/content + a `?token=` deep link. So a non-rendering crawl sees real content instead of the JS shell.

- Trust rails hold at the ranking layer: anomalous pools (>1000% total APY) `return` before aggregation — never shown, never counted; `$10M` TVL floor enforced.
- `test_token_pages.js` (17 assertions on real emitted HTML) + `test_fixtures/pools-sample.json`; added to the `test` chain; `npm run tokens` script added.
- `specs/014-sample-aaa.html` — one sample page for review.

## Phase 1 wires nothing (deliberate)
No `sitemap-*.xml`/`vercel.json`/`home.html`/canonical changes, and the generated `tokens/` prod output is **not** committed (only mock data is reachable in the sandbox — `yields.llama.fi` is 403-blocked, same wall as 013/018). Real pages + sitemap wiring + the canonical-consolidation decision (new `/tokens/<slug>` vs existing `?token=` self-canonical from 011) are **phase 2**, after a networked run produces pages a human can eyeball. Nothing enters the index until then.

## Verification
Verifier subagent (independent, adversarial): **PASS, risk HIGH, 7/7 criteria** — built an adversarial fixture proving $5B anomalous pools don't inflate rank and leave no trace on the page; boundary checks ($10M + 1000% inclusive; just over/under excluded); confirmed scope touches no SEO-surface files and no `tokens/` output was committed. `test_token_pages.js` 17/17; offline chain (`test_planner` 190 / `test_protocol_parsing` / `test_qualifier_fix` / `test_canonical` 24) exits 0. Full walkthrough + 5-question quiz: `product-loop-kit/specs/014-pr.md`.

Note: `test_smoke.js`/`test_search.js` in the npm chain need live network/browser (sandbox-blocked) — pre-existing limitation, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_