### PR TITLE
feat(014): relax token-page eligibility to $100K floor, ≥1 pool, no cap

### DIFF
--- a/generate-token-pages.js
+++ b/generate-token-pages.js
@@ -32,14 +32,20 @@ const https = require('https');
 const SITE_URL = 'https://www.defi.garden';
 const YIELDS_API = 'https://yields.llama.fi/pools';
 
-// --- Sanity rails & quality gate -------------------------------------------
-// Must stay in sync with app.js: DEFAULT_MIN_TVL (app.js:730) and
-// APY_SANITY_LIMIT (app.js:729), and with generate-sitemap.js's gate (013).
-// No shared import exists between these scripts.
-const DEFAULT_MIN_TVL = 10000000; // $10M floor
-const APY_SANITY_LIMIT = 1000;    // total APY above this may NEVER be shown
-const MIN_QUALIFYING_POOLS = 2;   // a token needs >=2 qualifying pools to earn a page
-const DEFAULT_LIMIT = 100;        // phase 1: top 100 tokens by TVL
+// --- Sanity rails & eligibility --------------------------------------------
+// APY_SANITY_LIMIT is a TRUST RAIL (mirrors app.js:729 / planner.js): a pool
+// whose total APY exceeds it may NEVER be shown or counted — untouched here.
+//
+// MIN_POOL_TVL is this SEO generator's OWN eligibility floor and DELIBERATELY
+// diverges from the app's DEFAULT_MIN_TVL ($10M, app.js:730) per human directive
+// 2026-07-11: the app's $10M floor governs what enters a savings PLAN (caution);
+// these static token pages exist to capture long-tail search traffic from newer
+// tokens, which a $10M floor + 2-pool minimum shut out. The pages still show
+// only real, non-anomalous pools — just down to a $100K floor, any count >= 1.
+const MIN_POOL_TVL = 100000;      // $100K eligibility floor for a page's pools
+const APY_SANITY_LIMIT = 1000;    // TRUST RAIL: total APY above this may NEVER be shown
+const MIN_QUALIFYING_POOLS = 1;   // a token needs >=1 qualifying pool to earn a page
+const DEFAULT_LIMIT = 0;          // 0 = no cap: a page for every eligible token
 const POOLS_PER_PAGE = 8;         // how many pools to list on each page
 
 // Token symbol validity — mirrors generate-sitemap.js isValidToken.
@@ -52,7 +58,7 @@ function isAnomalousApy(pool) {
   return poolTotalApy(pool) > APY_SANITY_LIMIT;
 }
 function isQualifyingPool(pool) {
-  return (pool.tvlUsd || 0) >= DEFAULT_MIN_TVL && !isAnomalousApy(pool);
+  return (pool.tvlUsd || 0) >= MIN_POOL_TVL && !isAnomalousApy(pool);
 }
 function isValidToken(symbol) {
   if (!symbol) return false;
@@ -96,12 +102,13 @@ function tokenSlug(symbol) {
  * Anomalous pools never count toward the gate and never enter `pools`.
  */
 function rankTopTokens(pools, limit) {
-  const cap = limit || DEFAULT_LIMIT;
+  // cap: falsy/0/undefined = no cap (a page for every eligible token).
+  const cap = (limit == null ? DEFAULT_LIMIT : limit);
   const byToken = new Map(); // symbol -> { totalTvl, qualifyingCount, pools:[] }
 
   pools.forEach(p => {
     if (isAnomalousApy(p)) return;            // trust rail: never display/count anomalies
-    if ((p.tvlUsd || 0) < DEFAULT_MIN_TVL) return; // qualifying pools only
+    if ((p.tvlUsd || 0) < MIN_POOL_TVL) return; // eligibility floor
     tokenSymbols(p).forEach(sym => {
       if (!isValidToken(sym)) return;
       if (!byToken.has(sym)) byToken.set(sym, { totalTvl: 0, qualifyingCount: 0, pools: [] });
@@ -126,7 +133,7 @@ function rankTopTokens(pools, limit) {
   });
 
   records.sort((a, b) => b.totalTvl - a.totalTvl);
-  return records.slice(0, cap);
+  return (cap && cap > 0) ? records.slice(0, cap) : records;
 }
 
 /** Render a single token's static landing page as an HTML string. */
@@ -136,8 +143,9 @@ function renderTokenPage(rec) {
   const appUrl = `${SITE_URL}/?token=${encodeURIComponent(rec.symbol)}`;
   const bestApy = Math.max(...rec.pools.map(poolTotalApy));
   const title = `${sym} DeFi Yields — Live Pools by TVL | DeFi Garden 🌱`;
+  const poolWord = rec.qualifyingCount === 1 ? 'pool' : 'pools';
   const description =
-    `${rec.qualifyingCount} live ${sym} pools above the $10M TVL floor, up to ` +
+    `${rec.qualifyingCount} live ${sym} ${poolWord} above the $100K TVL floor, up to ` +
     `${formatApy(bestApy)} APY, across ${new Set(rec.pools.map(p => p.chain)).size} chains. ` +
     `Honest yields from DefiLlama data — no anomalous rates.`;
 
@@ -179,7 +187,7 @@ function renderTokenPage(rec) {
 </head>
 <body>
     <h1>${sym} DeFi Yields</h1>
-    <p class="sub">${escapeHtml(String(rec.qualifyingCount))} live pools above the $10M TVL floor · ranked by TVL</p>
+    <p class="sub">${escapeHtml(String(rec.qualifyingCount))} live ${poolWord} above the $100K TVL floor · ranked by TVL</p>
     <a class="cta" href="${appUrl}">See live ${sym} pools &rarr;</a>
     <div class="scroll">
     <table>
@@ -191,7 +199,7 @@ ${rows}
       </tbody>
     </table>
     </div>
-    <p class="note">Yields are live from DefiLlama and pass DeFi Garden's trust filters (≥ $10M TVL, anomalous rates excluded). Not financial advice — education only.</p>
+    <p class="note">Yields are live from DefiLlama and pass DeFi Garden's trust filters (≥ $100K TVL, anomalous rates excluded). Not financial advice — education only.</p>
     <p class="note"><a href="${SITE_URL}/">DeFi Garden 🌱</a> — plan your DeFi savings by goal.</p>
 </body>
 </html>
@@ -255,5 +263,5 @@ if (require.main === module) {
 module.exports = {
   rankTopTokens, renderTokenPage, tokenSlug, isQualifyingPool, isAnomalousApy,
   isValidToken, poolTotalApy, formatUsd, formatApy,
-  DEFAULT_MIN_TVL, APY_SANITY_LIMIT, MIN_QUALIFYING_POOLS, DEFAULT_LIMIT, SITE_URL
+  MIN_POOL_TVL, APY_SANITY_LIMIT, MIN_QUALIFYING_POOLS, DEFAULT_LIMIT, SITE_URL
 };

--- a/product-loop-kit/specs/014-pr.md
+++ b/product-loop-kit/specs/014-pr.md
@@ -56,4 +56,4 @@ Verifier subagent (independent): **PASS, HIGH, 7/7** — including an adversaria
 7. Did the app/planner $10M trust rail (`DEFAULT_MIN_TVL`) change?
    A. Yes, lowered to $100K  · B. No — only the SEO generator's own floor changed; app/planner + 013 sitemap gate untouched  · C. It was removed
 
-<!-- answers addendum: Ni1CICA3OkI= -->
+<!-- answers addendum: NjpCICA3OkI= -->

--- a/product-loop-kit/specs/014-pr.md
+++ b/product-loop-kit/specs/014-pr.md
@@ -39,3 +39,21 @@ Verifier subagent (independent): **PASS, HIGH, 7/7** — including an adversaria
    A. Any single pool  · B. ≥2 pools at ≥$10M TVL, non-anomalous (the 013 gate)  · C. Top APY
 
 <!-- answers: MTpCICAyOkMgIDM6QiAgNDpDICA1OkI= -->
+
+---
+
+## Amendment (2026-07-11): relaxed eligibility to $100K floor, ≥1 pool, no cap
+
+**Why:** human directive — the original $10M floor + 2-pool minimum shut out newer tokens, which drive a lot of search traffic. 2026 SEO note: thin content is a *dataset* problem, not a template one — these pages carry real per-token pool data (unique value), so lowering the floor captures long-tail demand without minting empty pages; single-pool pages are thinner, so phase-2 publish scale + internal linking is ticketed.
+
+**What changed (generator only):** `MIN_POOL_TVL = 100000` (was $10M), `MIN_QUALIFYING_POOLS = 1` (was 2), `DEFAULT_LIMIT = 0` = no cap (`--limit N` still caps to top-N by TVL). Anomaly exclusion (>1000% APY) unchanged — anomalous pools never show, never count, never inflate rank. App/planner `DEFAULT_MIN_TVL $10M` and the 013 sitemap gate are NOT touched. Tests: 20 assertions (added single-pool inclusion, sub-$100K drop, no-cap, and an adversarial $900M-anomaly-leaves-no-trace check).
+
+**Verified:** verifier subagent PASS, HIGH, 7/7 — proved the anomaly rail holds at the lower floor and scope touches no app/sitemap files.
+
+### Quiz addendum
+6. After this amendment, what earns a token a page?
+   A. Top-100 by TVL only  · B. ≥1 non-anomalous pool with TVL ≥ $100K, no cap  · C. Any pool at all
+7. Did the app/planner $10M trust rail (`DEFAULT_MIN_TVL`) change?
+   A. Yes, lowered to $100K  · B. No — only the SEO generator's own floor changed; app/planner + 013 sitemap gate untouched  · C. It was removed
+
+<!-- answers addendum: Ni1CICA3OkI= -->

--- a/product-loop-kit/specs/014-sample-aaa.html
+++ b/product-loop-kit/specs/014-sample-aaa.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AAA DeFi Yields — Live Pools by TVL | DeFi Garden 🌱</title>
-    <meta name="description" content="3 live AAA pools above the $10M TVL floor, up to 5.00% APY, across 3 chains. Honest yields from DefiLlama data — no anomalous rates.">
-    <link rel="canonical" href="https://www.defi.garden/tokens/aaa">
+    <title>BIG DeFi Yields — Live Pools by TVL | DeFi Garden 🌱</title>
+    <meta name="description" content="2 live BIG pools above the $100K TVL floor, up to 4.10% APY, across 2 chains. Honest yields from DefiLlama data — no anomalous rates.">
+    <link rel="canonical" href="https://www.defi.garden/tokens/big">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="AAA DeFi Yields — Live Pools by TVL | DeFi Garden 🌱">
-    <meta property="og:description" content="3 live AAA pools above the $10M TVL floor, up to 5.00% APY, across 3 chains. Honest yields from DefiLlama data — no anomalous rates.">
-    <meta property="og:url" content="https://www.defi.garden/tokens/aaa">
+    <meta property="og:title" content="BIG DeFi Yields — Live Pools by TVL | DeFi Garden 🌱">
+    <meta property="og:description" content="2 live BIG pools above the $100K TVL floor, up to 4.10% APY, across 2 chains. Honest yields from DefiLlama data — no anomalous rates.">
+    <meta property="og:url" content="https://www.defi.garden/tokens/big">
     <meta property="og:image" content="https://www.defi.garden/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="robots" content="index,follow">
@@ -28,9 +28,9 @@
     </style>
 </head>
 <body>
-    <h1>AAA DeFi Yields</h1>
-    <p class="sub">3 live pools above the $10M TVL floor · ranked by TVL</p>
-    <a class="cta" href="https://www.defi.garden/?token=AAA">See live AAA pools &rarr;</a>
+    <h1>BIG DeFi Yields</h1>
+    <p class="sub">2 live pools above the $100K TVL floor · ranked by TVL</p>
+    <a class="cta" href="https://www.defi.garden/?token=BIG">See live BIG pools &rarr;</a>
     <div class="scroll">
     <table>
       <thead>
@@ -49,16 +49,10 @@
           <td class="num">4.00%</td>
           <td class="num">$300M</td>
         </tr>
-        <tr>
-          <td>morpho</td>
-          <td>Arbitrum</td>
-          <td class="num">5.00%</td>
-          <td class="num">$120M</td>
-        </tr>
       </tbody>
     </table>
     </div>
-    <p class="note">Yields are live from DefiLlama and pass DeFi Garden's trust filters (≥ $10M TVL, anomalous rates excluded). Not financial advice — education only.</p>
+    <p class="note">Yields are live from DefiLlama and pass DeFi Garden's trust filters (≥ $100K TVL, anomalous rates excluded). Not financial advice — education only.</p>
     <p class="note"><a href="https://www.defi.garden/">DeFi Garden 🌱</a> — plan your DeFi savings by goal.</p>
 </body>
 </html>

--- a/product-loop-kit/specs/014.md
+++ b/product-loop-kit/specs/014.md
@@ -39,6 +39,14 @@ HIGH — generates SEO surface (even though phase 1 doesn't wire it, it's an SEO
 ## Open questions
 None blocking phase 1. Phase 2 needs a human decision: canonical consolidation between the new static `/tokens/<slug>` pages and the existing `?token=<SYMBOL>` app URLs before both are indexable (avoid self-competition).
 
+## Amendment (2026-07-11, human directive — supersedes the floor/gate/cap above)
+The original $10M floor + ≥2-pool gate + top-100 cap shut out newer tokens, which drive a lot of search traffic. New eligibility (generator-only; app/planner `DEFAULT_MIN_TVL $10M` and the 013 sitemap gate are NOT changed here):
+- **Floor $100K** (`MIN_POOL_TVL`), not $10M — captures long-tail/newer-token demand.
+- **No minimum pool count** (`MIN_QUALIFYING_POOLS = 1`) — a token earns a page if it has ≥1 qualifying pool.
+- **No cap** by default (`DEFAULT_LIMIT = 0`) — a page per eligible token; `--limit N` still caps to top-N by TVL for a phased publish.
+- **Anomaly exclusion (>1000% APY) stays** — untouched trust rail; anomalous pools never show, never count, never inflate rank.
+- 2026 SEO caveat (research): thin content is a dataset problem, not a template problem. These pages carry real per-token pool data (unique value), but single-pool pages are thinner — phase 2 must decide publish scale + internal linking so we capture newer-token traffic without minting thin pages Google skips. Filed as follow-on tickets.
+
 ## Territory notes
 - `generate-stories.js` is the closest precedent: fetchPoolData, escapeHtml, futureValue, formatUsd/formatApy/formatTvl, self-canonical page template — mirror it.
 - `generate-sitemap.js` already carries the 013 quality-gate constants + `isQualifyingPool`/`isAnomalousApy`/`isValidToken`/`getPoolType` — mirror the same logic and the "must stay in sync with app.js" comments (no shared import exists between scripts).

--- a/test_fixtures/pools-sample.json
+++ b/test_fixtures/pools-sample.json
@@ -1,15 +1,10 @@
 [
-  { "symbol": "AAA", "project": "aave-v3", "chain": "Ethereum", "tvlUsd": 500000000, "apyBase": 4.1, "apyReward": 0 },
-  { "symbol": "AAA", "project": "compound-v3", "chain": "Base", "tvlUsd": 300000000, "apyBase": 3.8, "apyReward": 0.2 },
-  { "symbol": "AAA", "project": "morpho", "chain": "Arbitrum", "tvlUsd": 120000000, "apyBase": 5.0, "apyReward": 0 },
-  { "symbol": "BBB", "project": "curve", "chain": "Ethereum", "tvlUsd": 60000000, "apyBase": 6.2, "apyReward": 1.1 },
-  { "symbol": "BBB", "project": "convex", "chain": "Ethereum", "tvlUsd": 40000000, "apyBase": 7.0, "apyReward": 2.0 },
-  { "symbol": "CCC", "project": "aave-v3", "chain": "Polygon", "tvlUsd": 90000000, "apyBase": 3.0, "apyReward": 0 },
-  { "symbol": "CCC", "project": "tinypool", "chain": "Polygon", "tvlUsd": 500000, "apyBase": 9.0, "apyReward": 0 },
-  { "symbol": "DDD", "project": "smallcap", "chain": "Base", "tvlUsd": 2000000, "apyBase": 8.0, "apyReward": 0 },
-  { "symbol": "DDD", "project": "smallcap2", "chain": "Base", "tvlUsd": 3000000, "apyBase": 8.5, "apyReward": 0 },
-  { "symbol": "EEE", "project": "realpool", "chain": "Ethereum", "tvlUsd": 50000000, "apyBase": 6.0, "apyReward": 0 },
-  { "symbol": "EEE", "project": "degenfarm", "chain": "Solana", "tvlUsd": 80000000, "apyBase": 1500, "apyReward": 400 },
-  { "symbol": "USDC.E", "project": "aave-v3", "chain": "Arbitrum", "tvlUsd": 45000000, "apyBase": 4.5, "apyReward": 0 },
-  { "symbol": "USDC.E", "project": "stargate", "chain": "Optimism", "tvlUsd": 35000000, "apyBase": 5.1, "apyReward": 0.4 }
+  { "symbol": "BIG", "project": "aave-v3", "chain": "Ethereum", "tvlUsd": 500000000, "apyBase": 4.1, "apyReward": 0 },
+  { "symbol": "BIG", "project": "compound-v3", "chain": "Base", "tvlUsd": 300000000, "apyBase": 3.8, "apyReward": 0.2 },
+  { "symbol": "MID", "project": "curve", "chain": "Ethereum", "tvlUsd": 5000000, "apyBase": 6.2, "apyReward": 1.1 },
+  { "symbol": "ANOM", "project": "realpool", "chain": "Ethereum", "tvlUsd": 2000000, "apyBase": 6.0, "apyReward": 0 },
+  { "symbol": "ANOM", "project": "degenfarm", "chain": "Solana", "tvlUsd": 900000000, "apyBase": 1500, "apyReward": 600 },
+  { "symbol": "USDC.E", "project": "aave-v3", "chain": "Arbitrum", "tvlUsd": 200000, "apyBase": 4.5, "apyReward": 0 },
+  { "symbol": "SMALL", "project": "newproto", "chain": "Base", "tvlUsd": 150000, "apyBase": 9.0, "apyReward": 0 },
+  { "symbol": "DUST", "project": "dustpool", "chain": "Solana", "tvlUsd": 50000, "apyBase": 12.0, "apyReward": 0 }
 ]

--- a/test_token_pages.js
+++ b/test_token_pages.js
@@ -1,6 +1,10 @@
-/* Unit tests for the static token-page generator (spec 014, phase 1).
+/* Unit tests for the static token-page generator (spec 014).
    Runs the generator's pure functions against a crafted fixture and asserts
-   on the real emitted HTML. Run: node test_token_pages.js */
+   on the real emitted HTML. Run: node test_token_pages.js
+
+   Eligibility (human directive 2026-07-11): a token earns a page if it has
+   >=1 pool with TVL >= $100K that is NOT anomalous (>1000% APY). No minimum
+   pool count, no cap by default. The anomaly exclusion is a trust rail. */
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
@@ -12,50 +16,62 @@ function test(name, fn) {
   catch (err) { console.error('  ✗ ' + name + '\n    ' + err.message); process.exitCode = 1; }
 }
 
-// Fixture crafted to exercise every branch. TVL in USD.
-// AAA: 3 qualifying pools, highest aggregate TVL  -> emitted, rank #1
-// BBB: 2 qualifying pools, lower aggregate TVL     -> emitted, rank #2
-// CCC: 1 qualifying pool                           -> dropped (gate < 2)
-// DDD: 2 pools but both below the $10M TVL floor   -> dropped
-// EEE: 2 pools where one is anomalous (>1000% APY) -> anomaly excluded, left with 1 -> dropped
-// USDC.E: dotted symbol, 2 qualifying pools        -> emitted, slug-safe
+// Fixture branches:
+// BIG    : 2 pools ($500M + $300M)              -> qualifies, rank #1
+// MID    : 1 pool ($5M)                          -> qualifies (single pool ok)
+// ANOM   : 1 real ($2M) + 1 anomalous ($900M @2100%) -> anomaly excluded, qualifies via the $2M pool
+// USDC.E : 1 pool ($200K), dotted symbol         -> qualifies, slug-safe
+// SMALL  : 1 pool ($150K), newer token           -> qualifies (above the $100K floor)
+// DUST   : 1 pool ($50K)                          -> dropped (below the $100K floor)
 const pools = JSON.parse(fs.readFileSync(path.join(__dirname, 'test_fixtures', 'pools-sample.json'), 'utf8'));
-const ranked = gen.rankTopTokens(pools, 100);
+const ranked = gen.rankTopTokens(pools); // no cap
 const bySym = Object.fromEntries(ranked.map(r => [r.symbol, r]));
 
-console.log('rankTopTokens — gate + ranking + trust rails');
-test('emits exactly the tokens that clear the >=2 qualifying-pool gate', () => {
-  assert.deepStrictEqual(ranked.map(r => r.symbol).sort(), ['AAA', 'BBB', 'USDC.E']);
+console.log('rankTopTokens — $100K floor, >=1 pool, no cap');
+test('emits every token with >=1 qualifying pool; drops sub-$100K-only tokens', () => {
+  assert.deepStrictEqual(ranked.map(r => r.symbol).sort(), ['ANOM', 'BIG', 'MID', 'SMALL', 'USDC.E']);
 });
-test('ranks by aggregate qualifying TVL desc (AAA before BBB)', () => {
-  const iA = ranked.findIndex(r => r.symbol === 'AAA');
-  const iB = ranked.findIndex(r => r.symbol === 'BBB');
-  assert.ok(iA < iB, 'AAA should rank above BBB');
-  assert.ok(bySym['AAA'].totalTvl > bySym['BBB'].totalTvl);
+test('single-pool tokens are included (no >=2 minimum)', () => {
+  assert.strictEqual(bySym['MID'].qualifyingCount, 1);
+  assert.strictEqual(bySym['SMALL'].qualifyingCount, 1);
+  assert.strictEqual(bySym['USDC.E'].qualifyingCount, 1);
 });
-test('single-qualifying-pool token (CCC) is dropped', () => {
-  assert.ok(!bySym['CCC']);
+test('newer/low-TVL token above the floor qualifies (SMALL @ $150K)', () => {
+  assert.ok(bySym['SMALL']);
 });
-test('sub-floor token (DDD) is dropped', () => {
-  assert.ok(!bySym['DDD']);
+test('token whose only pool is below $100K is dropped (DUST @ $50K)', () => {
+  assert.ok(!bySym['DUST']);
 });
-test('anomalous pool excluded from content AND gate (EEE dropped to <2)', () => {
-  assert.ok(!bySym['EEE'], 'EEE had 1 real + 1 anomalous pool, should not clear the gate');
+test('ranks by aggregate qualifying TVL desc', () => {
+  assert.deepStrictEqual(ranked.map(r => r.symbol), ['BIG', 'MID', 'ANOM', 'USDC.E', 'SMALL']);
+});
+
+console.log('trust rail — anomaly exclusion (untouched)');
+test('anomalous pool excluded from content AND count AND TVL (ANOM)', () => {
+  assert.strictEqual(bySym['ANOM'].qualifyingCount, 1, 'anomalous pool must not be counted');
+  assert.strictEqual(bySym['ANOM'].totalTvl, 2000000, 'anomalous $900M pool must not inflate TVL');
+  assert.strictEqual(bySym['ANOM'].pools.length, 1);
 });
 test('no rendered pool anywhere is anomalous (>1000% total APY)', () => {
   ranked.forEach(r => r.pools.forEach(p => {
     assert.ok(gen.poolTotalApy(p) <= gen.APY_SANITY_LIMIT, r.symbol + ' has an anomalous pool');
   }));
 });
-test('every rendered pool clears the $10M TVL floor', () => {
+test('every rendered pool clears the $100K floor', () => {
   ranked.forEach(r => r.pools.forEach(p => {
-    assert.ok((p.tvlUsd || 0) >= gen.DEFAULT_MIN_TVL, r.symbol + ' has a sub-floor pool');
+    assert.ok((p.tvlUsd || 0) >= gen.MIN_POOL_TVL, r.symbol + ' has a sub-floor pool');
   }));
 });
-test('cap is honored (limit=1 -> single top token AAA)', () => {
+
+console.log('cap handling');
+test('no cap by default returns all eligible tokens', () => {
+  assert.strictEqual(gen.rankTopTokens(pools).length, 5);
+  assert.strictEqual(gen.rankTopTokens(pools, 0).length, 5);
+});
+test('explicit --limit caps to top-N by TVL (limit=1 -> BIG)', () => {
   const top1 = gen.rankTopTokens(pools, 1);
   assert.strictEqual(top1.length, 1);
-  assert.strictEqual(top1[0].symbol, 'AAA');
+  assert.strictEqual(top1[0].symbol, 'BIG');
 });
 
 console.log('tokenSlug — URL/filesystem safety');
@@ -68,33 +84,34 @@ test('slug has no unsafe chars', () => {
 });
 
 console.log('renderTokenPage — server-delivered SEO content');
-const html = gen.renderTokenPage(bySym['AAA']);
-test('self-canonical to /tokens/<slug>', () => {
-  assert.ok(html.includes('<link rel="canonical" href="https://www.defi.garden/tokens/aaa">'), 'missing self-canonical');
+const html = gen.renderTokenPage(bySym['BIG']);
+test('self-canonical to /tokens/<slug> (not the ?token= app URL)', () => {
+  assert.ok(html.includes('<link rel="canonical" href="https://www.defi.garden/tokens/big">'), 'missing self-canonical');
 });
 test('server-delivered <title> present in raw HTML (no JS)', () => {
-  assert.ok(/<title>AAA DeFi Yields[^<]*<\/title>/.test(html), 'missing title');
+  assert.ok(/<title>BIG DeFi Yields[^<]*<\/title>/.test(html), 'missing title');
 });
 test('server-delivered meta description present', () => {
   assert.ok(/<meta name="description" content="[^"]+">/.test(html), 'missing description');
 });
 test('links into the live app at ?token=<SYMBOL>', () => {
-  assert.ok(html.includes('https://www.defi.garden/?token=AAA'), 'missing app deep link');
+  assert.ok(html.includes('https://www.defi.garden/?token=BIG'), 'missing app deep link');
 });
 test('renders >=1 real pool row with en-US formatted numbers', () => {
   assert.ok(/<td class="num">\d/.test(html), 'no formatted numeric cell');
-  assert.ok(html.includes('%'), 'no APY');
-  assert.ok(html.includes('$'), 'no TVL');
+  assert.ok(html.includes('%') && html.includes('$'), 'no APY/TVL');
 });
-test('indexable (robots index,follow — these pages are meant to be found)', () => {
+test('indexable (robots index,follow)', () => {
   assert.ok(html.includes('content="index,follow"'), 'should be indexable');
 });
-test('HTML is escaped (no raw unescaped angle-brackets in content values)', () => {
-  // project names etc. go through escapeHtml; sanity-check the helper is wired
-  const evil = gen.renderTokenPage({ symbol: 'X<Y', slug: 'x-y', qualifyingCount: 2,
-    totalTvl: 2e7, pools: [{ project: '<script>', chain: 'Base', tvlUsd: 1e7, apyBase: 5, apyReward: 0 },
-                            { project: 'aave', chain: 'Base', tvlUsd: 1e7, apyBase: 4, apyReward: 0 }] });
-  assert.ok(!evil.includes('<script>'), 'unescaped project name leaked into HTML');
+test('single-pool page uses singular "pool" wording', () => {
+  const midHtml = gen.renderTokenPage(bySym['MID']);
+  assert.ok(/1 live pool above/.test(midHtml), 'expected singular "pool"');
+});
+test('HTML is escaped (malicious project name cannot inject markup)', () => {
+  const evil = gen.renderTokenPage({ symbol: 'X', slug: 'x', qualifyingCount: 1,
+    totalTvl: 2e7, pools: [{ project: '<script>alert(1)</script>', chain: 'Base', tvlUsd: 1e7, apyBase: 5, apyReward: 0 }] });
+  assert.ok(!evil.includes('<script>alert(1)</script>'), 'unescaped project name leaked into HTML');
   assert.ok(evil.includes('&lt;script&gt;'), 'expected escaped project name');
 });
 


### PR DESCRIPTION
Follow-up to #107 per human directive (2026-07-11): the $10M floor + 2-pool minimum shut out newer tokens that drive search traffic.

## Change (token-page generator only)
- `MIN_POOL_TVL = $100K` (was $10M) — captures long-tail/newer-token demand
- `MIN_QUALIFYING_POOLS = 1` (was 2) — a token earns a page with ≥1 qualifying pool
- `DEFAULT_LIMIT = 0` — no cap by default; `--limit N` still caps to top-N by TVL for a phased publish
- **Anomaly exclusion (>1000% APY) unchanged** — trust rail holds; anomalous pools never show/count/inflate rank
- **Not touched**: app/planner `DEFAULT_MIN_TVL $10M`, the 013 sitemap gate, `app.js`, `canonical.js`, `sitemap-*.xml`, `vercel.json`, `home.html`

## Why it's safe
The app's $10M floor (what enters a savings *plan*) is a different job and is unchanged. Only this SEO generator's own floor moved, under explicit human direction — not a NEVER-list trust-rail weakening.

## Verification
Verifier subagent: **PASS, HIGH, 7/7** — adversarial check proved the fixture's $900M @2100% pool leaves zero trace and ANOM ranks by its real $2M pool (not the anomaly); $100K floor enforced (a $50K-only token is dropped); scope touches no app/sitemap files; `git ls-files tokens/` empty. `test_token_pages.js` 20/20; offline chain (`test_planner` 190 / `test_protocol_parsing` / `test_qualifier_fix` / `test_canonical` 24) exits 0. Explainer + quiz amendment: `product-loop-kit/specs/014-pr.md`.

2026 SEO note (research): thin content is a dataset problem, not a template one — single-pool pages still carry unique per-token data, but phase-2 publish scale + internal linking is ticketed to avoid minting pages Google skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_