### PR TITLE
feat(025): concrete prefilled projection on the "Garden this pool" CTA

### DIFF
--- a/PoolDetail.js
+++ b/PoolDetail.js
@@ -184,7 +184,13 @@ function PoolDetail({
   const PROJECTION_YEARS = 5;
   const projectionApy = applyDegenHaircut ? totalApy / 3 : totalApy;
   const projectionAmount = _futureValue(PROJECTION_MONTHLY, projectionApy, PROJECTION_YEARS);
-  const gardenThisPoolHref = `plan.html?goal=retirement&pace=${gardenPersona}&monthly=${PROJECTION_MONTHLY}`;
+  // Prefill the planner horizon (years) too, so the recipient lands on exactly
+  // this pool's projection (025). The deep link never carries the pool's APY —
+  // the planner computes from its own blended, sanity-capped rate.
+  const gardenThisPoolHref = `plan.html?goal=retirement&pace=${gardenPersona}&monthly=${PROJECTION_MONTHLY}&years=${PROJECTION_YEARS}`;
+  // Concrete CTA (025): show the projected outcome ON the button — but NEVER for
+  // an anomalous pool (trust rail: anomalous rates are flagged, never hyped).
+  const showConcreteCta = !isAnomalous;
 
   return React.createElement('div', {
     className: 'pool-detail-container',
@@ -471,10 +477,17 @@ function PoolDetail({
             href: gardenThisPoolHref,
             onClick: () => {
               if (typeof Analytics !== 'undefined') {
-                Analytics.trackPoolClick(pool, 'garden_cta', { investmentAmount: PROJECTION_MONTHLY });
+                Analytics.trackPoolClick(pool, 'garden_cta', {
+                  investmentAmount: PROJECTION_MONTHLY,
+                  projectionYears: PROJECTION_YEARS,
+                  ctaVariant: showConcreteCta ? 'concrete' : 'generic'
+                });
               }
             }
-          }, t ? t('gardenThisPoolCta') : 'Garden this pool →'),
+          }, showConcreteCta
+            ? (t ? t('gardenThisPoolCtaConcrete', projectionAmount, PROJECTION_YEARS)
+                 : `Garden this pool → ~$${Math.round(projectionAmount).toLocaleString('en-US')} in ${PROJECTION_YEARS}y`)
+            : (t ? t('gardenThisPoolCta') : 'Garden this pool →')),
           React.createElement('p', { className: 'pool-action-hint' },
             t ? t('plannerCtaHint') : 'No wallet needed'
           ),

--- a/product-loop-kit/specs/025-notes.md
+++ b/product-loop-kit/specs/025-notes.md
@@ -1,0 +1,8 @@
+# 025 build notes
+
+- CTA text: added `gardenThisPoolCtaConcrete(amount, years)` (EN + KO), reusing 019's `projectionAmount` so the button and the projection block always agree. EN "Garden this pool → ~$X in 5y"; KO "이 풀 가든하기 → 5년 후 약 <amount>".
+- Trust rail honored: `showConcreteCta = !isAnomalous`. Anomalous pools keep the generic CTA — the projected number (which for a >1000% pool would be absurd) never reaches the button. Verified the anomaly branch by code trace.
+- Deep link: appended `&years=${PROJECTION_YEARS}` (=5). The planner's `decodePlanFromUrl` reads `years`; no planner.js change. The link never carries the pool APY — planner computes from its own blended sanity-capped rate.
+- Instrumentation: `garden_cta` now sends `ctaVariant` ('concrete'|'generic') + `projectionYears`, so the concrete-vs-generic lift is measurable against `plan_created`.
+- Deviations: none. Followed 019's existing variables and formatters exactly.
+- Verification: `node --check` clean on both files; executed the translation functions for EN + KO (both render correctly, en-US and Korean formatting); offline test chain (test_planner 190, test_protocol_parsing, test_qualifier_fix, test_canonical 24, test_token_pages 20) exits 0. Playwright on the real `/?pool=` route not runnable here (yields.llama.fi 403-blocked) — same limitation as 019; verified by code trace + translation execution.

--- a/product-loop-kit/specs/025-pr.md
+++ b/product-loop-kit/specs/025-pr.md
@@ -1,0 +1,38 @@
+# 025 — PR explainer (HIGH tier): concrete prefilled projection on the "Garden this pool" CTA
+
+## Goal
+Lift `garden_cta → plan_created` (a north-star path) by making the value legible at the moment of action: put the concrete projected outcome on the button and land the recipient on exactly that projection.
+
+## Intuition
+019 already computes an honest projection ("$200/mo grows to ~$X in 5y") and shows it in a separate block, while the button says only "Garden this pool →". Moving the number onto the button — and prefilling the planner horizon so the destination matches — closes the gap between the promise and the click.
+
+## What changed (reading order)
+1. `PoolDetail.js` — `showConcreteCta = !isAnomalous`. For non-anomalous pools the CTA renders `gardenThisPoolCtaConcrete(projectionAmount, PROJECTION_YEARS)` → "Garden this pool → ~$X in 5y", reusing the **same** `projectionAmount` the projection block shows (degen ⅓ haircut already baked in via `projectionApy`). For anomalous pools it falls back to the generic "Garden this pool →".
+2. Deep link gains `&years=5` so the planner opens prefilled to this exact projection (goal=retirement, pace=<persona>, monthly=200, years=5). The link never carries the pool's APY — the planner computes from its own sanity-capped blended rate.
+3. `garden_cta` now sends `ctaVariant` ('concrete'|'generic') + `projectionYears` so the lift is measurable.
+4. `translations.js` — new `gardenThisPoolCtaConcrete` in EN + KO.
+
+## The trust rail (why the gate matters)
+An anomalous pool (total APY > 1000%) would project an absurd number. Surfacing that on a button is exactly the hype the trust rails forbid. So the concrete number is gated to non-anomalous pools only; anomalous pools keep the generic CTA and still show their ⚠ warning. The projected number and the deep link are otherwise unchanged from 019.
+
+## Deviations
+None. Reuses 019's `projectionAmount`, `gardenPersona`, `isAnomalous`, `PROJECTION_YEARS` and the existing formatters.
+
+## Verification
+Verifier subagent (independent): **PASS, HIGH, 6/6** — traced the anomaly gate, confirmed the CTA reuses the same haircut-adjusted amount, deep link carries years=5 and no APY, instrumentation + EN/KO both present. `node --check` clean; offline chain (test_planner 190 / protocol_parsing / qualifier_fix / canonical 24 / token_pages 20) exits 0; both translation functions execute and render. Playwright on the real `/?pool=` route not runnable here (yields.llama.fi 403-blocked) — verified by code trace + translation execution, per 018/019 precedent.
+
+---
+
+## Quiz (answers base64 at the bottom)
+1. When does the CTA show the concrete projected number?
+   A. Always  · B. Only for non-anomalous pools (`showConcreteCta = !isAnomalous`)  · C. Only in Korean
+2. Where does the number on the button come from?
+   A. A new recomputation  · B. The pool's raw APY  · C. The same `projectionAmount` the projection block uses (degen haircut applied)
+3. What did the deep link gain?
+   A. The pool's APY  · B. `years=5`, so the planner opens prefilled to this projection  · C. Nothing
+4. Why keep the generic CTA for anomalous pools?
+   A. Laziness  · B. KO has no translation  · C. Trust rail — an anomalous rate must never be hyped on a button
+5. How is the change measurable?
+   A. It isn't  · B. `garden_cta` sends `ctaVariant`/`projectionYears` → compare CTR to `plan_created`  · C. Only via GSC
+
+<!-- answers: MTpCICAyOkMgIDM6QiAgNDpDICA1OkI= -->

--- a/product-loop-kit/specs/025.md
+++ b/product-loop-kit/specs/025.md
@@ -1,0 +1,35 @@
+# Spec 025: Concrete prefilled projection on the "Garden this pool" CTA
+
+## Evidence
+019 shipped the pool-detail "Garden this pool" CTA + an honest mini-projection ("$200/mo in this pool grows to ~$X in 5y"), instrumented as `garden_cta`; 020 gave it a denominator (`pool_view`). Human directive 2026-07-11: build the concrete-projection improvement now. Today the CTA is generic ("Garden this pool →") and the projected number lives only in a separate block; the deep link prefills `goal/pace/monthly` but not the horizon, so the recipient doesn't land on exactly this projection.
+
+## Hypothesis
+Putting the concrete projected outcome ON the button and prefilling the planner horizon makes the value legible at the point of action, lifting `garden_cta → plan_created`. Measurable via `garden_cta` (now with `ctaVariant`) → `plan_created`.
+
+## Change (PoolDetail.js + translations.js)
+1. CTA text becomes concrete for **non-anomalous** pools: "Garden this pool → ~$X in 5y" (X = the same `projectionAmount` the projection block already computes, degen ⅓ haircut applied where the pool maps to the degen band). New key `gardenThisPoolCtaConcrete(amount, years)`, EN + KO.
+2. **Trust rail**: for anomalous pools (`totalApy > APY_SANITY_LIMIT`), the CTA stays the generic "Garden this pool →" — an anomalous rate is flagged, NEVER hyped on a button. Gated on `showConcreteCta = !isAnomalous`.
+3. Deep link prefills the horizon: `&years=${PROJECTION_YEARS}` added to `gardenThisPoolHref` (planner decodes `years`; it never carries the pool's APY — the planner computes from its own sanity-capped blended rate, unchanged).
+4. Instrumentation: `garden_cta` now also sends `projectionYears` and `ctaVariant` ('concrete' | 'generic') so the lift is measurable.
+5. EN + KO for every new string; all numbers via existing en-US / Korean formatters.
+
+OUT of scope: planner.js internals, the projection block copy (019 owns it), trust-rail values, `?pool=` routing.
+
+## Acceptance criteria
+- [ ] Non-anomalous pool: CTA renders "Garden this pool → ~$<projectionAmount> in 5y" with the same amount as the projection block (degen haircut applied where applicable)
+- [ ] Anomalous pool: CTA stays generic "Garden this pool →" (no projected number) — verify the anomaly path
+- [ ] Deep link includes `years=5`; opening it lands the planner prefilled (goal=retirement, pace=<persona>, monthly=200, years=5)
+- [ ] `garden_cta` fires with `ctaVariant` + `projectionYears`
+- [ ] EN + KO keys present and render (execute the translation function for both)
+- [ ] `node test_planner.js && node test_protocol_parsing.js && node test_qualifier_fix.js && node test_canonical.js && node test_token_pages.js` exit 0; `node --check PoolDetail.js` + `translations.js` clean; timeboxed 5 min
+
+## Measurement
+`garden_cta` (ctaVariant=concrete) → `plan_created` CTR vs the prior generic baseline, 14-day window. Decision rule: if concrete lifts CTR, keep; if flat/down after ≥30 garden_cta events, revert to generic.
+
+## Risk tier (builder's guess — verifier assigns independently)
+LOW/HIGH boundary — copy + a deep-link param + instrumentation on a user-facing render path. Verifier assigns; if HIGH, explainer + quiz in specs/025-pr.md.
+
+## Territory notes
+- `projectionAmount`/`gardenPersona`/`isAnomalous`/`PROJECTION_YEARS` already exist in PoolDetail.js (019). Reuse; don't recompute.
+- The projection block (PoolDetail.js ~661) already formats the same amount — the CTA reuses `projectionAmount` for consistency.
+- Verify via Playwright on the real `/?pool=` route if live data reachable; this sandbox blocks `yields.llama.fi`, so fall back to code trace + translation-function execution (documented, per 018/019 precedent).

--- a/translations.js
+++ b/translations.js
@@ -89,6 +89,7 @@ const translations = {
     // Honest mini-projection (pool-detail)
     projectionHeading: "The Long Game",
     projectionBody: (monthly, years, amount) => `$${Number(monthly || 0).toLocaleString('en-US')}/mo in this pool grows to ~$${Number(amount || 0).toLocaleString('en-US', { maximumFractionDigits: 0 })} in ${years}y at current rates.`,
+    gardenThisPoolCtaConcrete: (amount, years) => `Garden this pool → ~$${Number(amount || 0).toLocaleString('en-US', { maximumFractionDigits: 0 })} in ${years}y`,
     poolDegenHaircutNote: (headline) => `Projected at ⅓ haircut (${headline} headline) — farm rates decay. Active management required.`,
 
     // Calculator disclaimers
@@ -585,6 +586,7 @@ const translations = {
     // Honest mini-projection (pool-detail)
     projectionHeading: "장기적으로 보면",
     projectionBody: (monthly, years, amount) => `이 풀에 월 ${formatKoreanCurrency(monthly)}을 넣으면 ${years}년 후 현재 수익률 기준 약 ${formatKoreanCurrency(Number(amount || 0))}이 됩니다.`,
+    gardenThisPoolCtaConcrete: (amount, years) => `이 풀 가든하기 → ${years}년 후 약 ${formatKoreanCurrency(Number(amount || 0))}`,
     poolDegenHaircutNote: (headline) => `⅓ 할인 적용 (헤드라인 ${headline}) — 팜 수익률은 빠르게 감소. 적극적 관리 필요.`,
 
     // Calculator disclaimers


### PR DESCRIPTION
Ships backlog item 025 per `product-loop-kit/specs/025.md` (human directive 2026-07-11).

## What
- The "Garden this pool" CTA now shows the concrete projected outcome for **non-anomalous** pools: "Garden this pool → ~$X in 5y", reusing 019's `projectionAmount` (degen ⅓ haircut applied where applicable).
- **Trust rail**: anomalous pools (>1000% APY) keep the generic "Garden this pool →" — a flagged rate is never hyped on a button.
- Deep link prefills the planner horizon (`&years=5`), so the recipient lands on exactly this projection; it never carries the pool's APY.
- `garden_cta` now sends `ctaVariant` ('concrete'|'generic') + `projectionYears` for measurement.
- EN + KO both added.

## Verification
Verifier subagent: **PASS, risk HIGH, 6/6** — traced the `showConcreteCta = !isAnomalous` gate (anomalous → generic, no number), confirmed the CTA reuses the same haircut-adjusted amount as the projection block, deep link carries `years=5` and no APY, instrumentation + EN/KO present. `node --check` clean; offline chain (`test_planner` 190 / `test_protocol_parsing` / `test_qualifier_fix` / `test_canonical` 24 / `test_token_pages` 20) exits 0; both translation functions execute and render. Explainer + quiz: `product-loop-kit/specs/025-pr.md`.

Note: Playwright on the real `/?pool=` route isn't runnable in this sandbox (`yields.llama.fi` 403-blocked) — verified by code trace + translation execution, per 018/019 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_