### PR TITLE
feat(023): token-page content depth + internal linking (thin-content mitigation)

### DIFF
--- a/generate-token-pages.js
+++ b/generate-token-pages.js
@@ -136,18 +136,56 @@ function rankTopTokens(pools, limit) {
   return (cap && cap > 0) ? records.slice(0, cap) : records;
 }
 
+/**
+ * Related tokens for internal linking (023): up to `n` other ranked tokens,
+ * co-chain ones first (share a chain with `rec`), then top-TVL others. `all`
+ * arrives TVL-desc so ordering is preserved. Internal links keep pages out of
+ * the orphan set (2026 SEO: unlinked pages don't get indexed).
+ */
+function relatedFor(rec, all, n) {
+  const cap = n || 6;
+  const chains = new Set(rec.pools.map(p => p.chain));
+  const others = (all || []).filter(r => r.symbol !== rec.symbol);
+  const coChain = others.filter(r => r.pools.some(p => chains.has(p.chain)));
+  const coSet = new Set(coChain);
+  const rest = others.filter(r => !coSet.has(r));
+  return coChain.concat(rest).slice(0, cap).map(r => ({ symbol: r.symbol, slug: r.slug }));
+}
+
 /** Render a single token's static landing page as an HTML string. */
-function renderTokenPage(rec) {
+function renderTokenPage(rec, related) {
   const sym = escapeHtml(rec.symbol);
   const pageUrl = `${SITE_URL}/tokens/${rec.slug}`;
   const appUrl = `${SITE_URL}/?token=${encodeURIComponent(rec.symbol)}`;
   const bestApy = Math.max(...rec.pools.map(poolTotalApy));
+  const chainCount = new Set(rec.pools.map(p => p.chain)).size;
   const title = `${sym} DeFi Yields — Live Pools by TVL | DeFi Garden 🌱`;
   const poolWord = rec.qualifyingCount === 1 ? 'pool' : 'pools';
+  const chainWord = chainCount === 1 ? 'chain' : 'chains';
   const description =
     `${rec.qualifyingCount} live ${sym} ${poolWord} above the $100K TVL floor, up to ` +
-    `${formatApy(bestApy)} APY, across ${new Set(rec.pools.map(p => p.chain)).size} chains. ` +
+    `${formatApy(bestApy)} APY, across ${chainCount} ${chainWord}. ` +
     `Honest yields from DefiLlama data — no anomalous rates.`;
+
+  // Unique per-token intro from real data (023: content depth — this reads
+  // token-specifically even with the symbol removed, so it's not thin).
+  const top = rec.pools[0];
+  const intro =
+    `${sym}'s largest live pool is ${escapeHtml(top.project || '—')} on ${escapeHtml(top.chain || '—')} ` +
+    `at ${formatApy(poolTotalApy(top))} (${formatUsd(top.tvlUsd)} TVL). ` +
+    `${rec.qualifyingCount} ${sym} ${poolWord} across ${chainCount} ${chainWord} clear ` +
+    `DeFi Garden's $100K TVL floor, ${formatUsd(rec.totalTvl)} in total.`;
+
+  const relatedLinks = (related || []).map(r =>
+    `<a href="${SITE_URL}/tokens/${r.slug}">${escapeHtml(r.symbol)}</a>`).join('\n        ');
+  const relatedBlock = relatedLinks
+    ? `    <nav class="related" aria-label="Related tokens">
+      <h2>Related tokens</h2>
+      <div class="related-links">
+        ${relatedLinks}
+      </div>
+    </nav>\n`
+    : '';
 
   const rows = rec.pools.map(p => `        <tr>
           <td>${escapeHtml(p.project || '—')}</td>
@@ -181,6 +219,10 @@ function renderTokenPage(rec) {
       th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #e2e8f0; }
       td.num, th.num { text-align: right; }
       .cta { display: inline-block; margin: 12px 0 24px; padding: 12px 20px; border: 1px solid #3b82f6; border-radius: 10px; color: #3b82f6; text-decoration: none; font-weight: 600; }
+      .intro { color: #334155; margin: 4px 0 16px; }
+      .related { margin: 28px 0 8px; }
+      .related h2 { font-size: 1rem; margin-bottom: 8px; }
+      .related-links a { display: inline-block; margin: 0 8px 8px 0; padding: 6px 12px; border: 1px solid #cbd5e1; border-radius: 8px; color: #3b82f6; text-decoration: none; font-size: 0.9rem; }
       .note { color: #64748b; font-size: 0.9rem; }
       .scroll { overflow-x: auto; }
     </style>
@@ -188,6 +230,7 @@ function renderTokenPage(rec) {
 <body>
     <h1>${sym} DeFi Yields</h1>
     <p class="sub">${escapeHtml(String(rec.qualifyingCount))} live ${poolWord} above the $100K TVL floor · ranked by TVL</p>
+    <p class="intro">${intro}</p>
     <a class="cta" href="${appUrl}">See live ${sym} pools &rarr;</a>
     <div class="scroll">
     <table>
@@ -199,7 +242,7 @@ ${rows}
       </tbody>
     </table>
     </div>
-    <p class="note">Yields are live from DefiLlama and pass DeFi Garden's trust filters (≥ $100K TVL, anomalous rates excluded). Not financial advice — education only.</p>
+${relatedBlock}    <p class="note">Yields are live from DefiLlama and pass DeFi Garden's trust filters (≥ $100K TVL, anomalous rates excluded). Not financial advice — education only.</p>
     <p class="note"><a href="${SITE_URL}/">DeFi Garden 🌱</a> — plan your DeFi savings by goal.</p>
 </body>
 </html>
@@ -251,7 +294,7 @@ async function main() {
   const outDir = path.resolve(args.out);
   if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
   ranked.forEach(rec => {
-    fs.writeFileSync(path.join(outDir, `${rec.slug}.html`), renderTokenPage(rec));
+    fs.writeFileSync(path.join(outDir, `${rec.slug}.html`), renderTokenPage(rec, relatedFor(rec, ranked)));
   });
   console.log(`📝 Wrote ${ranked.length} pages to ${args.out}/`);
 }
@@ -261,7 +304,7 @@ if (require.main === module) {
 }
 
 module.exports = {
-  rankTopTokens, renderTokenPage, tokenSlug, isQualifyingPool, isAnomalousApy,
+  rankTopTokens, renderTokenPage, relatedFor, tokenSlug, isQualifyingPool, isAnomalousApy,
   isValidToken, poolTotalApy, formatUsd, formatApy,
   MIN_POOL_TVL, APY_SANITY_LIMIT, MIN_QUALIFYING_POOLS, DEFAULT_LIMIT, SITE_URL
 };

--- a/product-loop-kit/specs/014-sample-aaa.html
+++ b/product-loop-kit/specs/014-sample-aaa.html
@@ -23,6 +23,10 @@
       th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #e2e8f0; }
       td.num, th.num { text-align: right; }
       .cta { display: inline-block; margin: 12px 0 24px; padding: 12px 20px; border: 1px solid #3b82f6; border-radius: 10px; color: #3b82f6; text-decoration: none; font-weight: 600; }
+      .intro { color: #334155; margin: 4px 0 16px; }
+      .related { margin: 28px 0 8px; }
+      .related h2 { font-size: 1rem; margin-bottom: 8px; }
+      .related-links a { display: inline-block; margin: 0 8px 8px 0; padding: 6px 12px; border: 1px solid #cbd5e1; border-radius: 8px; color: #3b82f6; text-decoration: none; font-size: 0.9rem; }
       .note { color: #64748b; font-size: 0.9rem; }
       .scroll { overflow-x: auto; }
     </style>
@@ -30,6 +34,7 @@
 <body>
     <h1>BIG DeFi Yields</h1>
     <p class="sub">2 live pools above the $100K TVL floor · ranked by TVL</p>
+    <p class="intro">BIG's largest live pool is aave-v3 on Ethereum at 4.10% ($500M TVL). 2 BIG pools across 2 chains clear DeFi Garden's $100K TVL floor, $800M in total.</p>
     <a class="cta" href="https://www.defi.garden/?token=BIG">See live BIG pools &rarr;</a>
     <div class="scroll">
     <table>
@@ -52,6 +57,15 @@
       </tbody>
     </table>
     </div>
+    <nav class="related" aria-label="Related tokens">
+      <h2>Related tokens</h2>
+      <div class="related-links">
+        <a href="https://www.defi.garden/tokens/mid">MID</a>
+        <a href="https://www.defi.garden/tokens/anom">ANOM</a>
+        <a href="https://www.defi.garden/tokens/small">SMALL</a>
+        <a href="https://www.defi.garden/tokens/usdc-e">USDC.E</a>
+      </div>
+    </nav>
     <p class="note">Yields are live from DefiLlama and pass DeFi Garden's trust filters (≥ $100K TVL, anomalous rates excluded). Not financial advice — education only.</p>
     <p class="note"><a href="https://www.defi.garden/">DeFi Garden 🌱</a> — plan your DeFi savings by goal.</p>
 </body>

--- a/product-loop-kit/specs/023-notes.md
+++ b/product-loop-kit/specs/023-notes.md
@@ -1,0 +1,5 @@
+# 023 build notes
+- Added relatedFor() + a unique per-token intro to generate-token-pages.js; exported relatedFor.
+- Internal links point at other /tokens/<slug> pages (co-chain first, self excluded) — implements the 2026 "no orphans" guidance.
+- Test bug caught during build: an early "no self-link" assertion matched the legitimate self-CANONICAL; scoped it to the related <nav> block. 26 assertions pass.
+- Sample refreshed (specs/014-sample-aaa.html). Offline chain green. No app/sitemap/routing changes.

--- a/product-loop-kit/specs/023-pr.md
+++ b/product-loop-kit/specs/023-pr.md
@@ -1,0 +1,31 @@
+# 023 — PR explainer (HIGH tier): token-page content depth + internal linking
+
+## Goal
+Make the 014 token pages worth indexing. After the $100K relax (#109) they're real but bare tables. 2026 SEO: thin = a *dataset* problem (strip the token symbol and a generic page is too shallow), and orphan pages (no internal links) don't get indexed. This adds unique per-token substance + internal links.
+
+## What changed (generate-token-pages.js + test)
+1. **Unique intro from real data** — "<SYM>'s largest live pool is <project> on <chain> at <apy> (<tvl>). N pools across M chains clear the $100K floor, <total> in total." Token-specific facts, so the page reads distinctly even with the symbol removed.
+2. **`relatedFor(rec, all)` + a "Related tokens" nav** — up to 6 internal `/tokens/<slug>` links, co-chain tokens first then top-TVL, self excluded, omitted when empty. No page is an orphan.
+3. Trust rails, ranking, floor, anomaly exclusion — all unchanged (the diff doesn't touch `rankTopTokens`'s gate). No app/sitemap/routing changes; no `tokens/` prod output committed.
+
+## Deviations
+An early test assertion flagged the page's own self-**canonical** as a "self-link"; scoped it to the `<nav>` block (the canonical self-ref is correct). 26 assertions pass.
+
+## Verification
+Verifier subagent: **PASS, HIGH, 3/3** — confirmed intros differ per token, related nav prefers co-chain and never self-links inside the nav, escaping holds on intro+related, the ANOM $900M @2100% fixture still leaves no trace, and scope touches no app/sitemap files. `test_token_pages.js` 26/26; offline chain exits 0.
+
+---
+
+## Quiz (answers base64 at the bottom)
+1. Why enrich the token pages now?
+   A. Bigger tables look nicer  · B. 2026 SEO — thin (generic) pages and orphan (unlinked) pages don't get indexed  · C. To change the trust rails
+2. Where does the per-token intro's data come from?
+   A. A hardcoded template  · B. An external API call  · C. The token's own top pool + qualifyingCount/chains/totalTvl
+3. How does the related nav order links?
+   A. Alphabetical  · B. Co-chain tokens first, then top-TVL, self excluded  · C. Random
+4. The page's canonical contains `/tokens/<slug>` for itself — is that a self-link bug?
+   A. Yes, remove it  · B. Yes, canonical must point elsewhere  · C. No — the self-canonical is correct; only the related *nav* must avoid a self-link
+5. Did this change the ranking/floor/anomaly gate?
+   A. Lowered the floor  · B. No — `rankTopTokens` gate untouched; only intro + related added  · C. Removed the anomaly exclusion
+
+<!-- answers: MTpCICAyOkMgIDM6QiAgNDpDICA1OkI= -->

--- a/product-loop-kit/specs/023.md
+++ b/product-loop-kit/specs/023.md
@@ -1,0 +1,14 @@
+# Spec 023: Token-page content depth + internal linking (thin-content mitigation)
+
+## Evidence
+2026 SEO scan (reports/2026-07-11-seo-2026.md): thin content is a DATASET problem, not a template one — if the modifier (token symbol) is removed and the page reads generic, it's too shallow; and indexing = indexable + canonical + INTERNALLY LINKED (orphan pages don't get indexed). 014's pages (post-$100K relax) are real but bare tables with no cross-links.
+
+## Change (generate-token-pages.js + test)
+1. Unique per-token intro from real data: "<SYM>'s largest live pool is <project> on <chain> at <apy> (<tvl>). N pools across M chains clear the $100K floor, <total> in total." Token-specific facts, not a fixed template.
+2. `relatedFor(rec, all)` — up to 6 related tokens, co-chain first then top-TVL, self excluded; rendered as a "Related tokens" nav of internal `/tokens/<slug>` links so no page is an orphan.
+3. Trust rails untouched (still only non-anomalous, ≥$100K pools; numbers via en-US helpers). No sitemap/vercel/app changes.
+
+## Acceptance criteria
+- [ ] Each page has a unique intro derived from its own top pool + totals; two tokens' intros differ
+- [ ] Related nav renders internal `/tokens/<slug>` links, co-chain preferred, never links to self; omitted when no related tokens
+- [ ] Trust rails intact; `node test_token_pages.js` + full offline chain exit 0

--- a/test_token_pages.js
+++ b/test_token_pages.js
@@ -115,4 +115,39 @@ test('HTML is escaped (malicious project name cannot inject markup)', () => {
   assert.ok(evil.includes('&lt;script&gt;'), 'expected escaped project name');
 });
 
+console.log('023 — content depth + internal linking');
+test('renders a unique per-token intro from real data (top pool + totals)', () => {
+  const big = gen.renderTokenPage(bySym['BIG'], gen.relatedFor(bySym['BIG'], ranked));
+  assert.ok(/class="intro"/.test(big), 'no intro block');
+  assert.ok(big.includes("BIG's largest live pool is aave-v3 on Ethereum"), 'intro not token-specific');
+});
+test('intro differs per token (dataset content, not a fixed template)', () => {
+  const a = gen.renderTokenPage(bySym['BIG'], []);
+  const b = gen.renderTokenPage(bySym['MID'], []);
+  const introA = a.match(/<p class="intro">([^<]*)</)[1];
+  const introB = b.match(/<p class="intro">([^<]*)</)[1];
+  assert.notStrictEqual(introA, introB, 'intros are identical across tokens');
+});
+test('relatedFor prefers co-chain tokens, excludes self, is slug-linkable', () => {
+  const rel = gen.relatedFor(bySym['BIG'], ranked);
+  assert.ok(rel.length >= 1, 'no related tokens');
+  assert.ok(!rel.some(r => r.symbol === 'BIG'), 'self appeared in related');
+  // BIG shares Ethereum/Base with MID(Ethereum) and ANOM(Ethereum) -> co-chain first
+  assert.strictEqual(rel[0].symbol, 'MID', 'expected a co-chain token first');
+});
+test('page renders a Related tokens nav with internal /tokens/ links', () => {
+  const big = gen.renderTokenPage(bySym['BIG'], gen.relatedFor(bySym['BIG'], ranked));
+  assert.ok(/class="related"/.test(big), 'no related nav');
+  assert.ok(big.includes('href="https://www.defi.garden/tokens/mid"'), 'no internal token link');
+});
+test('no self-link inside the related nav (canonical self-ref is fine)', () => {
+  const big = gen.renderTokenPage(bySym['BIG'], gen.relatedFor(bySym['BIG'], ranked));
+  const nav = big.match(/<nav class="related"[\s\S]*?<\/nav>/)[0];
+  assert.ok(!nav.includes('/tokens/big"'), 'related nav links back to its own page');
+});
+test('related nav omitted when there are no related tokens', () => {
+  const solo = gen.renderTokenPage(bySym['BIG'], []);
+  assert.ok(!/class="related"/.test(solo), 'related nav should be absent with no related tokens');
+});
+
 console.log(`\n${passed} assertions passed`);


### PR DESCRIPTION
Ships backlog item 023 per `product-loop-kit/specs/023.md` (evidence: `reports/2026-07-11-seo-2026.md`).

## What
- **Unique per-token intro** from the token's own data ("<SYM>'s largest live pool is <project> on <chain> at <apy> (<tvl>). N pools across M chains clear the $100K floor, <total> in total.") — token-specific, not a fixed template.
- **`relatedFor()` + a "Related tokens" nav** of up to 6 internal `/tokens/<slug>` links (co-chain first, self excluded, omitted when empty) so no page is an orphan.
- 2026 SEO basis: thin content is a *dataset* problem and orphan pages don't index. Trust rails, ranking, floor, and anomaly exclusion untouched; no app/sitemap/routing changes; no `tokens/` prod output committed.

## Verification
Verifier subagent: **PASS, risk HIGH, 3/3** — intros differ per token, related nav prefers co-chain and never self-links inside the nav (the self-canonical is correct), escaping holds, the ANOM $900M @2100% fixture still leaves no trace, scope clean. `test_token_pages.js` 26/26; offline chain (`test_planner` 190 / `test_protocol_parsing` / `test_qualifier_fix` / `test_canonical` 24) exits 0. Explainer + quiz: `product-loop-kit/specs/023-pr.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_