### PR TITLE
feat(028): restyle token pages to the app neumorphic design system (tokens only)

### DIFF
--- a/generate-token-pages.js
+++ b/generate-token-pages.js
@@ -210,28 +210,43 @@ function renderTokenPage(rec, related) {
     <meta name="twitter:card" content="summary_large_image">
     <meta name="robots" content="index,follow">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🌱</text></svg>">
+    <!-- Reuse the app's design system: style.css defines the neumorphic tokens
+         (--color-*, --neuro-*) + the brand gradient body. The scoped block below
+         styles this page with those tokens only — no hardcoded colors/gradients. -->
+    <link rel="stylesheet" href="/style.css">
     <style>
-      :root { color-scheme: light dark; }
-      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 820px; margin: 0 auto; padding: 24px; line-height: 1.6; }
-      h1 { font-size: 1.6rem; margin-bottom: 4px; }
-      .sub { color: #64748b; margin-top: 0; }
-      table { width: 100%; border-collapse: collapse; margin: 20px 0; }
-      th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #e2e8f0; }
-      td.num, th.num { text-align: right; }
-      .cta { display: inline-block; margin: 12px 0 24px; padding: 12px 20px; border: 1px solid #3b82f6; border-radius: 10px; color: #3b82f6; text-decoration: none; font-weight: 600; }
-      .intro { color: #334155; margin: 4px 0 16px; }
-      .related { margin: 28px 0 8px; }
-      .related h2 { font-size: 1rem; margin-bottom: 8px; }
-      .related-links a { display: inline-block; margin: 0 8px 8px 0; padding: 6px 12px; border: 1px solid #cbd5e1; border-radius: 8px; color: #3b82f6; text-decoration: none; font-size: 0.9rem; }
-      .note { color: #64748b; font-size: 0.9rem; }
+      .tp-wrap { max-width: 860px; margin: 0 auto; padding: 32px 20px; }
+      .tp-wrap h1 { font-size: 1.7rem; margin: 0 0 4px; color: var(--color-text); }
+      .tp-wrap .sub { color: var(--color-text-secondary); margin: 0 0 16px; }
+      .tp-wrap .intro { color: var(--color-text); margin: 4px 0 22px; line-height: 1.6; }
+      .tp-card { background: var(--color-surface); border-radius: var(--neuro-radius-lg); box-shadow: var(--neuro-shadow-raised); padding: 8px 18px; margin: 20px 0; }
+      .tp-card table { width: 100%; border-collapse: collapse; }
+      .tp-card th, .tp-card td { text-align: left; padding: 13px 8px; border-bottom: 1px solid var(--color-border); color: var(--color-text); }
+      .tp-card th { color: var(--color-text-secondary); font-weight: 600; }
+      .tp-card td.num, .tp-card th.num { text-align: right; }
+      .tp-card tr:last-child td { border-bottom: none; }
+      .tp-cta { display: inline-block; margin: 8px 0 4px; padding: 14px 24px; background: var(--color-surface); color: var(--color-primary); border-radius: var(--neuro-radius-md); box-shadow: var(--neuro-shadow-raised); text-decoration: none; font-weight: 600; transition: box-shadow .2s ease, transform .2s ease; }
+      .tp-cta:hover { box-shadow: var(--neuro-shadow-flat); transform: translateY(-2px); }
+      .tp-cta:active { box-shadow: var(--neuro-shadow-pressed); transform: translateY(1px); }
+      .tp-cta:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .related { margin: 30px 0 8px; }
+      .related h2 { font-size: 1rem; margin-bottom: 12px; color: var(--color-text); }
+      .related-links a { display: inline-block; margin: 0 8px 8px 0; padding: 8px 14px; background: var(--color-surface); color: var(--color-primary); border-radius: var(--neuro-radius-md); box-shadow: var(--neuro-shadow-subtle); text-decoration: none; font-size: .9rem; transition: box-shadow .2s ease; }
+      .related-links a:hover { box-shadow: var(--neuro-shadow-flat); }
+      .related-links a:active { box-shadow: var(--neuro-shadow-pressed); }
+      .related-links a:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .tp-wrap .note { color: var(--color-text-secondary); font-size: .9rem; }
       .scroll { overflow-x: auto; }
+      @media (prefers-reduced-motion: reduce) { .tp-cta, .related-links a { transition: none; } }
     </style>
 </head>
 <body>
+  <main class="tp-wrap">
     <h1>${sym} DeFi Yields</h1>
     <p class="sub">${escapeHtml(String(rec.qualifyingCount))} live ${poolWord} above the $100K TVL floor · ranked by TVL</p>
     <p class="intro">${intro}</p>
-    <a class="cta" href="${appUrl}">See live ${sym} pools &rarr;</a>
+    <a class="tp-cta" href="${appUrl}">See live ${sym} pools &rarr;</a>
+    <div class="tp-card">
     <div class="scroll">
     <table>
       <thead>
@@ -242,8 +257,10 @@ ${rows}
       </tbody>
     </table>
     </div>
+    </div>
 ${relatedBlock}    <p class="note">Yields are live from DefiLlama and pass DeFi Garden's trust filters (≥ $100K TVL, anomalous rates excluded). Not financial advice — education only.</p>
     <p class="note"><a href="${SITE_URL}/">DeFi Garden 🌱</a> — plan your DeFi savings by goal.</p>
+  </main>
 </body>
 </html>
 `;

--- a/product-loop-kit/specs/014-sample-aaa.html
+++ b/product-loop-kit/specs/014-sample-aaa.html
@@ -14,28 +14,43 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="robots" content="index,follow">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🌱</text></svg>">
+    <!-- Reuse the app's design system: style.css defines the neumorphic tokens
+         (--color-*, --neuro-*) + the brand gradient body. The scoped block below
+         styles this page with those tokens only — no hardcoded colors/gradients. -->
+    <link rel="stylesheet" href="/style.css">
     <style>
-      :root { color-scheme: light dark; }
-      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 820px; margin: 0 auto; padding: 24px; line-height: 1.6; }
-      h1 { font-size: 1.6rem; margin-bottom: 4px; }
-      .sub { color: #64748b; margin-top: 0; }
-      table { width: 100%; border-collapse: collapse; margin: 20px 0; }
-      th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #e2e8f0; }
-      td.num, th.num { text-align: right; }
-      .cta { display: inline-block; margin: 12px 0 24px; padding: 12px 20px; border: 1px solid #3b82f6; border-radius: 10px; color: #3b82f6; text-decoration: none; font-weight: 600; }
-      .intro { color: #334155; margin: 4px 0 16px; }
-      .related { margin: 28px 0 8px; }
-      .related h2 { font-size: 1rem; margin-bottom: 8px; }
-      .related-links a { display: inline-block; margin: 0 8px 8px 0; padding: 6px 12px; border: 1px solid #cbd5e1; border-radius: 8px; color: #3b82f6; text-decoration: none; font-size: 0.9rem; }
-      .note { color: #64748b; font-size: 0.9rem; }
+      .tp-wrap { max-width: 860px; margin: 0 auto; padding: 32px 20px; }
+      .tp-wrap h1 { font-size: 1.7rem; margin: 0 0 4px; color: var(--color-text); }
+      .tp-wrap .sub { color: var(--color-text-secondary); margin: 0 0 16px; }
+      .tp-wrap .intro { color: var(--color-text); margin: 4px 0 22px; line-height: 1.6; }
+      .tp-card { background: var(--color-surface); border-radius: var(--neuro-radius-lg); box-shadow: var(--neuro-shadow-raised); padding: 8px 18px; margin: 20px 0; }
+      .tp-card table { width: 100%; border-collapse: collapse; }
+      .tp-card th, .tp-card td { text-align: left; padding: 13px 8px; border-bottom: 1px solid var(--color-border); color: var(--color-text); }
+      .tp-card th { color: var(--color-text-secondary); font-weight: 600; }
+      .tp-card td.num, .tp-card th.num { text-align: right; }
+      .tp-card tr:last-child td { border-bottom: none; }
+      .tp-cta { display: inline-block; margin: 8px 0 4px; padding: 14px 24px; background: var(--color-surface); color: var(--color-primary); border-radius: var(--neuro-radius-md); box-shadow: var(--neuro-shadow-raised); text-decoration: none; font-weight: 600; transition: box-shadow .2s ease, transform .2s ease; }
+      .tp-cta:hover { box-shadow: var(--neuro-shadow-flat); transform: translateY(-2px); }
+      .tp-cta:active { box-shadow: var(--neuro-shadow-pressed); transform: translateY(1px); }
+      .tp-cta:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .related { margin: 30px 0 8px; }
+      .related h2 { font-size: 1rem; margin-bottom: 12px; color: var(--color-text); }
+      .related-links a { display: inline-block; margin: 0 8px 8px 0; padding: 8px 14px; background: var(--color-surface); color: var(--color-primary); border-radius: var(--neuro-radius-md); box-shadow: var(--neuro-shadow-subtle); text-decoration: none; font-size: .9rem; transition: box-shadow .2s ease; }
+      .related-links a:hover { box-shadow: var(--neuro-shadow-flat); }
+      .related-links a:active { box-shadow: var(--neuro-shadow-pressed); }
+      .related-links a:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .tp-wrap .note { color: var(--color-text-secondary); font-size: .9rem; }
       .scroll { overflow-x: auto; }
+      @media (prefers-reduced-motion: reduce) { .tp-cta, .related-links a { transition: none; } }
     </style>
 </head>
 <body>
+  <main class="tp-wrap">
     <h1>BIG DeFi Yields</h1>
     <p class="sub">2 live pools above the $100K TVL floor · ranked by TVL</p>
     <p class="intro">BIG's largest live pool is aave-v3 on Ethereum at 4.10% ($500M TVL). 2 BIG pools across 2 chains clear DeFi Garden's $100K TVL floor, $800M in total.</p>
-    <a class="cta" href="https://www.defi.garden/?token=BIG">See live BIG pools &rarr;</a>
+    <a class="tp-cta" href="https://www.defi.garden/?token=BIG">See live BIG pools &rarr;</a>
+    <div class="tp-card">
     <div class="scroll">
     <table>
       <thead>
@@ -57,6 +72,7 @@
       </tbody>
     </table>
     </div>
+    </div>
     <nav class="related" aria-label="Related tokens">
       <h2>Related tokens</h2>
       <div class="related-links">
@@ -68,5 +84,6 @@
     </nav>
     <p class="note">Yields are live from DefiLlama and pass DeFi Garden's trust filters (≥ $100K TVL, anomalous rates excluded). Not financial advice — education only.</p>
     <p class="note"><a href="https://www.defi.garden/">DeFi Garden 🌱</a> — plan your DeFi savings by goal.</p>
+  </main>
 </body>
 </html>

--- a/product-loop-kit/specs/028-notes.md
+++ b/product-loop-kit/specs/028-notes.md
@@ -1,0 +1,5 @@
+# 028 build notes
+- Restyle only (per human choice): token-page template now links /style.css and uses the app's --color-*/--neuro-* tokens; content unchanged.
+- Tokens-only scoped CSS: neuro surface card, press physics + focus ring on CTA/chips, reduced-motion honored. Zero hardcoded hex (grep-verified, new assertion added).
+- CTA class renamed .cta -> .tp-cta (avoid colliding with any app .cta); tests key off href/content, not class, so unaffected. 27 assertions pass.
+- Visual correctness (light/dark) needs a browser eyeball on the pulled page — not verifiable in this no-browser env; structural/token correctness is.

--- a/product-loop-kit/specs/028-pr.md
+++ b/product-loop-kit/specs/028-pr.md
@@ -1,0 +1,7 @@
+# 028 — PR explainer (LOW tier): token-page restyle to the app design system
+
+**What:** the static token-page generator now links `/style.css` and styles its content with the app's neumorphic design tokens (`--color-*`, `--neuro-*`) instead of a bare inline stylesheet — neumorphic surface card for the pool table, press physics + focus ring on the CTA and related chips, reduced-motion honored, light/dark for free via prefers-color-scheme. Content is unchanged (restyle only, per human choice); no hardcoded hex, no gradients.
+
+**Why:** the generated page looked off-brand vs the app, which violates the "reuse components / neumorphic tokens only" standing decision.
+
+**Verified:** verifier PASS, LOW — zero hardcoded hex in the scoped style block, tokens all defined in style.css, trust-rail gate byte-identical, 27 assertions + offline chain green. Residual: the actual light/dark look needs a human browser eyeball on the pulled page.

--- a/product-loop-kit/specs/028.md
+++ b/product-loop-kit/specs/028.md
@@ -1,0 +1,19 @@
+# Spec 028: Token-page design — reuse the app's neumorphic design system (restyle only)
+
+## Evidence
+Human review of a real generated /tokens/usdc page: the static page used a bare inline stylesheet (plain table, off-palette greys) — off-brand and against the standing decision "REUSE COMPONENTS, KEEP DESIGN TIDY / neumorphic tokens only; gradient/off-brand one-offs are a verifier FAIL." Human directive: reuse the app's components/design. Decision: RESTYLE ONLY — keep the content (pool list + intro + related nav), make it on-brand; do NOT differentiate content or add planner CTAs (that was declined).
+
+## Change (generate-token-pages.js only)
+1. Link the app stylesheet: `<link rel="stylesheet" href="/style.css">` — inherits the brand gradient body, font, and all `--color-*`/`--neuro-*` tokens (light + dark via prefers-color-scheme, no JS).
+2. Replace the bare inline CSS with a scoped block using DESIGN TOKENS ONLY: neumorphic surface cards (`--color-surface` + `--neuro-shadow-raised` + `--neuro-radius-lg`), table borders via `--color-border`, text via `--color-text`/`--color-text-secondary`, a neumorphic CTA + related chips with press physics (`:active` → `--neuro-shadow-pressed` + translateY) and focus ring (`--focus-ring`), reduced-motion respected. No hardcoded hex/rgba, no gradients.
+3. Content unchanged (title/meta/canonical/intro/table/related/notes). Wrapped in a `.tp-wrap` main + `.tp-card`.
+
+## Acceptance criteria
+- [ ] Page links /style.css and styles content with neuro/color tokens; zero hardcoded hex in the scoped style block (grep-verifiable)
+- [ ] Neumorphic card for the table; CTA + chips have press physics + focus ring; reduced-motion honored
+- [ ] All prior content intact (self-canonical, server title/desc, pool rows, intro, related nav); trust rails/ranking untouched
+- [ ] `node test_token_pages.js` + full offline chain exit 0
+- [ ] Visual check on a REAL render (browser, light + dark) — human eyeball on the pulled page
+
+## Risk tier
+LOW/HIGH boundary — SEO-surface generator, but CSS-only (no content/logic change). Verifier assigns.

--- a/test_token_pages.js
+++ b/test_token_pages.js
@@ -104,6 +104,12 @@ test('renders >=1 real pool row with en-US formatted numbers', () => {
 test('indexable (robots index,follow)', () => {
   assert.ok(html.includes('content="index,follow"'), 'should be indexable');
 });
+test('reuses the app design system (links style.css) and uses neuro tokens, no hardcoded hex', () => {
+  assert.ok(html.includes('<link rel="stylesheet" href="/style.css">'), 'must link the app style.css');
+  assert.ok(html.includes('var(--neuro-shadow-raised)') && html.includes('var(--color-surface)'), 'must use neuro/color tokens');
+  const styleBlock = html.match(/<style>[\s\S]*?<\/style>/)[0];
+  assert.ok(!/#[0-9a-fA-F]{3,6}\b/.test(styleBlock), 'no hardcoded hex colors in the scoped style block');
+});
 test('single-pool page uses singular "pool" wording', () => {
   const midHtml = gen.renderTokenPage(bySym['MID']);
   assert.ok(/1 live pool above/.test(midHtml), 'expected singular "pool"');


### PR DESCRIPTION
Ships backlog item 028 per `product-loop-kit/specs/028.md` (human review of a real generated `/tokens/usdc` page: off-brand bare table).

## What (generate-token-pages.js only, restyle only)
- Links the app stylesheet `<link rel="stylesheet" href="/style.css">` → inherits the brand gradient body, font, and all `--color-*`/`--neuro-*` tokens (light + dark via prefers-color-scheme, no JS).
- Scoped CSS uses **design tokens only**: neumorphic surface card for the pool table, press physics (`:active` → `--neuro-shadow-pressed` + translateY) + focus ring (`--focus-ring`) on the CTA and related chips, reduced-motion honored. Zero hardcoded hex, no gradients.
- Content unchanged (self-canonical, server title/desc, pool table, intro, related nav); trust rails/ranking untouched.

## Verification
Verifier subagent: **PASS, LOW** — zero hardcoded hex in the scoped style block, all tokens defined in `style.css`, gate logic byte-identical (ANOM $900M @2100% still leaves no trace), scope clean, `test_token_pages.js` 27/27 + offline chain green. Explainer: `product-loop-kit/specs/028-pr.md`.

**One residual, by design:** the actual rendered look (light/dark) needs a human browser eyeball on the pulled page — can't be verified in a no-browser env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_