### PR TITLE
feat(021): real /tokens/ pages live via CI + token sitemap

### DIFF
--- a/.github/workflows/sitemap-update.yml
+++ b/.github/workflows/sitemap-update.yml
@@ -9,6 +9,7 @@ on:
     branches: [ main ]
     paths:
       - 'generate-sitemap.js'
+      - 'generate-token-pages.js'
       - 'package.json'
 
 jobs:
@@ -34,6 +35,12 @@ jobs:
     - name: Install dependencies
       run: npm install --only=production
     
+    - name: Generate token landing pages
+      run: |
+        echo "🌿 Generating static /tokens/ landing pages + sitemap..."
+        node generate-token-pages.js --out tokens --sitemap sitemap-token-pages.xml
+        echo "Pages: $(ls tokens | wc -l) · sitemap URLs: $(grep -c '<loc>' sitemap-token-pages.xml)"
+
     - name: Generate sitemap
       run: |
         echo "🚀 Generating fresh sitemap..."
@@ -82,7 +89,7 @@ jobs:
         git config --local user.email "alex@0xhodler.nl"
         git config --local user.name "alex0xhodler"
         
-        git add sitemap.xml robots.txt llms.txt llms-full.txt
+        git add sitemap.xml sitemap-token-pages.xml tokens robots.txt llms.txt llms-full.txt
         git commit -m "chore: update sitemap and LLM files with latest yields
         
         - Regenerated sitemap.xml with $(grep -c '<url>' sitemap.xml) URLs

--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -394,6 +394,15 @@ async function generateSitemapSuite() {
         indexXml += '  </sitemap>\n';
       }
     });
+    // Include the static /tokens/ landing-page sitemap (021) when it has been
+    // generated (generate-token-pages.js writes it in the same CI run). Kept
+    // discoverable via the index so crawlers find the real static pages.
+    if (fs.existsSync('sitemap-token-pages.xml')) {
+      indexXml += '  <sitemap>\n';
+      indexXml += `    <loc>${SITE_URL}sitemap-token-pages.xml</loc>\n`;
+      indexXml += `    <lastmod>${now}</lastmod>\n`;
+      indexXml += '  </sitemap>\n';
+    }
     indexXml += '</sitemapindex>';
     fs.writeFileSync('sitemap.xml', indexXml);
     console.log('✅ Generated sitemap.xml (Index)');

--- a/generate-token-pages.js
+++ b/generate-token-pages.js
@@ -266,6 +266,16 @@ ${relatedBlock}    <p class="note">Yields are live from DefiLlama and pass DeFi 
 `;
 }
 
+/** Render a sitemap (urlset) of all generated /tokens/<slug> URLs (021). */
+function renderTokenSitemap(ranked, lastmod) {
+  const urls = (ranked || []).map(rec =>
+    `  <url>\n    <loc>${SITE_URL}/tokens/${rec.slug}</loc>\n` +
+    (lastmod ? `    <lastmod>${lastmod}</lastmod>\n` : '') +
+    `    <changefreq>daily</changefreq>\n  </url>`).join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+}
+
 // --- IO layer (only runs as a script) --------------------------------------
 function fetchPoolData() {
   return new Promise((resolve, reject) => {
@@ -283,11 +293,13 @@ function fetchPoolData() {
 }
 
 function parseArgs(argv) {
-  const args = { fixture: process.env.POOLS_FIXTURE || null, out: 'tokens', limit: DEFAULT_LIMIT };
+  const args = { fixture: process.env.POOLS_FIXTURE || null, out: 'tokens', limit: DEFAULT_LIMIT, sitemap: 'sitemap-token-pages.xml' };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--fixture') args.fixture = argv[++i];
     else if (argv[i] === '--out') args.out = argv[++i];
     else if (argv[i] === '--limit') args.limit = parseInt(argv[++i], 10) || DEFAULT_LIMIT;
+    else if (argv[i] === '--sitemap') args.sitemap = argv[++i];
+    else if (argv[i] === '--no-sitemap') args.sitemap = null;
   }
   return args;
 }
@@ -314,6 +326,12 @@ async function main() {
     fs.writeFileSync(path.join(outDir, `${rec.slug}.html`), renderTokenPage(rec, relatedFor(rec, ranked)));
   });
   console.log(`📝 Wrote ${ranked.length} pages to ${args.out}/`);
+
+  if (args.sitemap) {
+    const lastmod = new Date().toISOString().slice(0, 10);
+    fs.writeFileSync(path.resolve(args.sitemap), renderTokenSitemap(ranked, lastmod));
+    console.log(`🗺️  Wrote ${args.sitemap} (${ranked.length} URLs)`);
+  }
 }
 
 if (require.main === module) {
@@ -321,7 +339,7 @@ if (require.main === module) {
 }
 
 module.exports = {
-  rankTopTokens, renderTokenPage, relatedFor, tokenSlug, isQualifyingPool, isAnomalousApy,
+  rankTopTokens, renderTokenPage, relatedFor, renderTokenSitemap, tokenSlug, isQualifyingPool, isAnomalousApy,
   isValidToken, poolTotalApy, formatUsd, formatApy,
   MIN_POOL_TVL, APY_SANITY_LIMIT, MIN_QUALIFYING_POOLS, DEFAULT_LIMIT, SITE_URL
 };

--- a/product-loop-kit/specs/021-notes.md
+++ b/product-loop-kit/specs/021-notes.md
@@ -1,0 +1,6 @@
+# 021 build notes
+- Real-page generation routed to CI (sitemap-update.yml) — the loop env can't reach yields.llama.fi, GitHub CI can. Mirrors how sitemap.xml/llms.txt already flow to main via that Action (generated-asset exemption from PR-per-change).
+- generate-token-pages.js: +renderTokenSitemap (exported), main() writes sitemap-token-pages.xml (default on; --no-sitemap for offline sample runs), --sitemap override. lastmod = today (Date OK in a plain node script).
+- generate-sitemap.js: conditional index entry (fs.existsSync). Ordering: token-pages step runs first in the workflow so the file exists when the index is built.
+- Could NOT run generate-sitemap.js or the Action here (need network); node --check clean, YAML valid, 30 token-page assertions + offline chain green. Residual = human triggers the Action + eyeballs /tokens/usdc after deploy.
+- Scale: no --limit in CI (per human's no-cap directive) — every eligible token (≥1 pool ≥$100K, non-anomalous) gets a page; the step logs the count. Add --limit N to the workflow to phase it if the count is too large.

--- a/product-loop-kit/specs/021-pr.md
+++ b/product-loop-kit/specs/021-pr.md
@@ -1,0 +1,36 @@
+# 021 — PR explainer (HIGH tier): real /tokens/ pages live via CI + token sitemap
+
+## Goal
+`/tokens/usdc` (and every token page) currently 404s — the generator (014/023/028) is on main but no pages were ever generated, committed, or deployed. This makes them real: generate them in CI (which has live-API access), commit them to main, and make them discoverable via a sitemap.
+
+## Why CI, not the loop or a laptop
+The build-loop env and this session can't reach `yields.llama.fi` (403). GitHub Actions can — and the repo already runs `sitemap-update.yml` daily to regenerate + commit `sitemap.xml`/`llms.txt` to main. Token pages are the same kind of generated SEO asset, so they ride the same Action (this is the generated-asset flow NORTH_STAR already exempts from PR-per-change).
+
+## What changed (reading order)
+1. **`generate-token-pages.js`** — `renderTokenSitemap(ranked, lastmod)` emits a urlset of every `/tokens/<slug>`; `main()` writes `sitemap-token-pages.xml` (default on; `--no-sitemap` for offline sample runs; `--sitemap <path>` override).
+2. **`generate-sitemap.js`** — adds `sitemap-token-pages.xml` to the sitemap **index** guarded by `fs.existsSync(...)`, so crawlers discover the static pages (and the index never references a missing file).
+3. **`.github/workflows/sitemap-update.yml`** — a "Generate token landing pages" step runs **before** the sitemap step (so the token sitemap exists when the index is built); the commit's `git add` now includes `tokens` + `sitemap-token-pages.xml`; the push-path trigger includes `generate-token-pages.js`.
+
+Trust rails, ranking, floor, anomaly gate — all untouched (the ANOM $900M @2100% fixture still leaves no trace). Both surfaces stay distinct + self-canonical (no consolidation).
+
+## The one thing this PR can't prove
+CI actually executing + real pages deploying needs a human to trigger the Action (`workflow_dispatch`) and eyeball `/tokens/usdc` after Vercel deploys. That's why it's HIGH and why the spec's "LIVE VERIFY" criterion is human-only.
+
+## Verification
+Verifier subagent: **PASS, HIGH, 4/4 loop-verifiable** — valid urlset (1 loc/token), `existsSync`-guarded index entry, correct workflow ordering + commit, trust rails intact, scope clean, YAML valid, `test_token_pages.js` 30/30 + offline chain green.
+
+---
+
+## Quiz (answers base64 at the bottom)
+1. Why was `/tokens/usdc` empty?
+   A. A bug in the router  · B. robots.txt blocked it  · C. The pages were never generated/committed/deployed — only the generator existed
+2. Why generate the real pages in GitHub CI rather than the build loop?
+   A. CI is cheaper  · B. The loop env can't reach yields.llama.fi (403); CI can, and already commits generated SEO assets to main  · C. It isn't — the loop does it
+3. How is the token sitemap kept from referencing a missing file?
+   A. A try/catch  · B. `fs.existsSync('sitemap-token-pages.xml')` guards the index entry  · C. It always references it
+4. Why does the token-pages step run before the sitemap step in the workflow?
+   A. Alphabetical  · B. No reason  · C. So `sitemap-token-pages.xml` exists when `generate-sitemap.js` builds the index
+5. What must a human still do?
+   A. Nothing  · B. Trigger the "Update Sitemap" Action and eyeball /tokens/usdc after deploy  · C. Rewrite the generator
+
+<!-- answers: MTpDICAyOkIgIDM6QiAgNDpDICA1OkI= -->

--- a/product-loop-kit/specs/021.md
+++ b/product-loop-kit/specs/021.md
@@ -1,0 +1,21 @@
+# Spec 021: 014 phase 2 — real /tokens/ pages live via CI + token sitemap
+
+## Evidence
+Human hit https://www.defi.garden/tokens/usdc → "nothing here". Root cause: the token-page GENERATOR (014/023/028) is on main, but no `tokens/` dir was ever generated+committed+deployed (phase 1 shipped the generator only; the loop env can't reach yields.llama.fi). So Vercel serves nothing at /tokens/<slug>.
+
+## Change
+Route real-page generation through the existing networked CI (`.github/workflows/sitemap-update.yml`, which has API access and already commits generated SEO assets to main):
+1. `generate-token-pages.js` emits `sitemap-token-pages.xml` (a urlset of every generated /tokens/<slug>) alongside the pages. New `--sitemap <path>` / `--no-sitemap`.
+2. `generate-sitemap.js` includes `sitemap-token-pages.xml` in the sitemap INDEX when the file exists (so crawlers discover the static pages).
+3. Workflow: a "Generate token landing pages" step runs BEFORE the sitemap step (so the index picks up the token sitemap); commit now adds `tokens/` + `sitemap-token-pages.xml`; workflow also triggers on `generate-token-pages.js` changes.
+KEEP BOTH surfaces distinct (self-canonical each) — no consolidation (standing decision).
+
+## Acceptance criteria
+- [ ] `renderTokenSitemap` emits a valid urlset, one <loc> per ranked token, pointing at /tokens/<slug>
+- [ ] generate-sitemap.js adds the token sitemap to the index only when present (existsSync guard)
+- [ ] Workflow generates pages+sitemap before the sitemap step and commits tokens/ + sitemap-token-pages.xml
+- [ ] Trust rails/ranking untouched; `node test_token_pages.js` + offline chain exit 0; YAML valid
+- [ ] LIVE VERIFY (human): trigger the "Update Sitemap" Action (workflow_dispatch); pages appear at /tokens/usdc after deploy
+
+## Risk tier
+HIGH — .github/workflows config + generated SEO surface. CI execution can't be verified in the loop env; residual = trigger the Action + watch.

--- a/test_token_pages.js
+++ b/test_token_pages.js
@@ -156,4 +156,23 @@ test('related nav omitted when there are no related tokens', () => {
   assert.ok(!/class="related"/.test(solo), 'related nav should be absent with no related tokens');
 });
 
+console.log('021 — token sitemap (renderTokenSitemap)');
+test('emits a valid urlset with one <loc> per ranked token', () => {
+  const xml = gen.renderTokenSitemap(ranked, '2026-07-11');
+  assert.ok(xml.startsWith('<?xml'), 'missing xml decl');
+  assert.ok(xml.includes('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'), 'missing urlset');
+  const locs = (xml.match(/<loc>/g) || []).length;
+  assert.strictEqual(locs, ranked.length, 'one loc per token');
+});
+test('sitemap URLs point at the static /tokens/<slug> pages', () => {
+  const xml = gen.renderTokenSitemap(ranked, '2026-07-11');
+  assert.ok(xml.includes('<loc>https://www.defi.garden/tokens/big</loc>'), 'missing token URL');
+  assert.ok(xml.includes('<lastmod>2026-07-11</lastmod>'), 'missing lastmod');
+});
+test('empty ranked list still yields a well-formed (empty) urlset', () => {
+  const xml = gen.renderTokenSitemap([], '2026-07-11');
+  assert.ok(xml.includes('<urlset') && xml.includes('</urlset>'), 'not well-formed');
+  assert.strictEqual((xml.match(/<loc>/g) || []).length, 0);
+});
+
 console.log(`\n${passed} assertions passed`);


### PR DESCRIPTION
Makes the token pages real. `/tokens/usdc` 404s today because the generator (014/023/028) is on main but no pages were ever generated/committed/deployed. This routes generation through the existing networked `sitemap-update.yml` Action (which has live-API access and already commits generated SEO assets to main).

## What changed
- **`generate-token-pages.js`** — `renderTokenSitemap()` + `main()` writes `sitemap-token-pages.xml` (a urlset of every `/tokens/<slug>`); new `--sitemap`/`--no-sitemap`.
- **`generate-sitemap.js`** — includes `sitemap-token-pages.xml` in the sitemap **index** when it exists (`fs.existsSync` guard), so crawlers discover the static pages.
- **`.github/workflows/sitemap-update.yml`** — "Generate token landing pages" step runs **before** the sitemap step; commit adds `tokens/` + `sitemap-token-pages.xml`; triggers on `generate-token-pages.js`.

Trust rails/ranking untouched; both surfaces stay distinct + self-canonical (no consolidation).

## Verification
Verifier subagent: **PASS, HIGH, 4/4 loop-verifiable** — valid urlset (1 loc/token), `existsSync`-guarded index entry, correct workflow ordering + commit, ANOM anomaly fixture still leaves no trace, scope clean, YAML valid, `test_token_pages.js` 30/30 + offline chain green. Explainer + quiz: `product-loop-kit/specs/021-pr.md`.

## ⚠️ Requires a human step to go live
CI execution + deploy can't be verified in the loop env. After merge: **Actions → "Update Sitemap" → Run workflow** (workflow_dispatch). It generates the real pages from live data, commits `tokens/` + the sitemap to main, Vercel deploys, and `/tokens/usdc` goes live. The step logs the page count (no `--limit` = every eligible token; add `--limit N` to phase it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_