### PR TITLE
feat(029): make token-page pool rows link to their detail pages

### DIFF
--- a/generate-token-pages.js
+++ b/generate-token-pages.js
@@ -187,12 +187,17 @@ function renderTokenPage(rec, related) {
     </nav>\n`
     : '';
 
-  const rows = rec.pools.map(p => `        <tr>
-          <td>${escapeHtml(p.project || '—')}</td>
+  const rows = rec.pools.map(p => {
+    // Each pool links to its detail page (the app matches pool.pool ===
+    // urlParams.pool). Falls back to the token app view if no id.
+    const poolHref = p.pool ? `${SITE_URL}/?pool=${encodeURIComponent(p.pool)}` : appUrl;
+    return `        <tr>
+          <td><a class="tp-pool-link" href="${poolHref}">${escapeHtml(p.project || '—')} &rarr;</a></td>
           <td>${escapeHtml(p.chain || '—')}</td>
           <td class="num">${formatApy(poolTotalApy(p))}</td>
           <td class="num">${formatUsd(p.tvlUsd)}</td>
-        </tr>`).join('\n');
+        </tr>`;
+  }).join('\n');
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -225,6 +230,12 @@ function renderTokenPage(rec, related) {
       .tp-card th { color: var(--color-text-secondary); font-weight: 600; }
       .tp-card td.num, .tp-card th.num { text-align: right; }
       .tp-card tr:last-child td { border-bottom: none; }
+      .tp-card tbody tr { transition: background .15s ease; }
+      .tp-card tbody tr:hover { background: var(--color-background); }
+      .tp-pool-link { color: var(--color-primary); text-decoration: none; font-weight: 500; }
+      .tp-pool-link:hover { text-decoration: underline; }
+      .tp-pool-link:focus-visible { outline: none; box-shadow: var(--focus-ring); border-radius: var(--neuro-radius-sm); }
+      @media (prefers-reduced-motion: reduce) { .tp-card tbody tr { transition: none; } }
       .tp-cta { display: inline-block; margin: 8px 0 4px; padding: 14px 24px; background: var(--color-surface); color: var(--color-primary); border-radius: var(--neuro-radius-md); box-shadow: var(--neuro-shadow-raised); text-decoration: none; font-weight: 600; transition: box-shadow .2s ease, transform .2s ease; }
       .tp-cta:hover { box-shadow: var(--neuro-shadow-flat); transform: translateY(-2px); }
       .tp-cta:active { box-shadow: var(--neuro-shadow-pressed); transform: translateY(1px); }

--- a/product-loop-kit/specs/014-sample-aaa.html
+++ b/product-loop-kit/specs/014-sample-aaa.html
@@ -29,6 +29,12 @@
       .tp-card th { color: var(--color-text-secondary); font-weight: 600; }
       .tp-card td.num, .tp-card th.num { text-align: right; }
       .tp-card tr:last-child td { border-bottom: none; }
+      .tp-card tbody tr { transition: background .15s ease; }
+      .tp-card tbody tr:hover { background: var(--color-background); }
+      .tp-pool-link { color: var(--color-primary); text-decoration: none; font-weight: 500; }
+      .tp-pool-link:hover { text-decoration: underline; }
+      .tp-pool-link:focus-visible { outline: none; box-shadow: var(--focus-ring); border-radius: var(--neuro-radius-sm); }
+      @media (prefers-reduced-motion: reduce) { .tp-card tbody tr { transition: none; } }
       .tp-cta { display: inline-block; margin: 8px 0 4px; padding: 14px 24px; background: var(--color-surface); color: var(--color-primary); border-radius: var(--neuro-radius-md); box-shadow: var(--neuro-shadow-raised); text-decoration: none; font-weight: 600; transition: box-shadow .2s ease, transform .2s ease; }
       .tp-cta:hover { box-shadow: var(--neuro-shadow-flat); transform: translateY(-2px); }
       .tp-cta:active { box-shadow: var(--neuro-shadow-pressed); transform: translateY(1px); }
@@ -58,13 +64,13 @@
       </thead>
       <tbody>
         <tr>
-          <td>aave-v3</td>
+          <td><a class="tp-pool-link" href="https://www.defi.garden/?pool=big-aave-v3-0">aave-v3 &rarr;</a></td>
           <td>Ethereum</td>
           <td class="num">4.10%</td>
           <td class="num">$500M</td>
         </tr>
         <tr>
-          <td>compound-v3</td>
+          <td><a class="tp-pool-link" href="https://www.defi.garden/?pool=big-compound-v3-1">compound-v3 &rarr;</a></td>
           <td>Base</td>
           <td class="num">4.00%</td>
           <td class="num">$300M</td>

--- a/product-loop-kit/specs/029-notes.md
+++ b/product-loop-kit/specs/029-notes.md
@@ -1,0 +1,5 @@
+# 029 build notes
+- Protocol cell -> <a class="tp-pool-link" href="/?pool=<id>"> with a "→" affordance; fallback to appUrl (/?token=) when p.pool is missing.
+- Fixture gained pool ids; 2 new assertions (row links to /?pool=<id>; no-id fallback). 32 assertions total. Tokens-only CSS, zero hardcoded hex.
+- Whole-row <a> isn't valid inside <tr>; linked the protocol (the pool's identity) + added a row hover to signal interactivity — accessible and no JS.
+- Does NOT touch ranking (the 0.00%-APY-at-top look the human noted) or indexing strategy — flagged for a separate quality decision.

--- a/product-loop-kit/specs/029.md
+++ b/product-loop-kit/specs/029.md
@@ -1,0 +1,19 @@
+# Spec 029: Token pages — clickable pool rows → pool-detail pages
+
+## Evidence
+Human review of the live /tokens/aave page: clicking a pool row does nothing. Each pool has an id the app deep-links via /?pool=<id> (app.js:1015 matches pool.pool === urlParams.pool) to the rich pool-detail page (019). The rows were static text.
+
+## Change (generate-token-pages.js)
+- Each pool row's protocol cell becomes a link to `${SITE_URL}/?pool=${encodeURIComponent(p.pool)}` (falls back to the token app view if a pool lacks an id). Adds row hover + a tokens-only link style + focus ring; reduced-motion honored.
+- This fixes the dead clicks AND adds genuine internal links to useful pages (a real quality/interlinking signal), not more templated filler.
+
+## Acceptance criteria
+- [ ] Each pool row links to /?pool=<its id>; fallback to /?token=<SYMBOL> when no id
+- [ ] Tokens-only styling (link + hover + focus ring), no hardcoded hex; reduced-motion honored
+- [ ] Trust rails/ranking/content otherwise unchanged; node test_token_pages.js + offline chain exit 0
+
+## Risk tier
+LOW/HIGH boundary — SEO-surface generator, additive links + CSS. Verifier assigns.
+
+## Note (separate, open)
+Does NOT address the broader thin-content/low-quality indexing risk the human raised — that's a strategy decision (differentiate content + be selective about which tokens get indexed) tracked separately.

--- a/test_fixtures/pools-sample.json
+++ b/test_fixtures/pools-sample.json
@@ -1,10 +1,74 @@
 [
-  { "symbol": "BIG", "project": "aave-v3", "chain": "Ethereum", "tvlUsd": 500000000, "apyBase": 4.1, "apyReward": 0 },
-  { "symbol": "BIG", "project": "compound-v3", "chain": "Base", "tvlUsd": 300000000, "apyBase": 3.8, "apyReward": 0.2 },
-  { "symbol": "MID", "project": "curve", "chain": "Ethereum", "tvlUsd": 5000000, "apyBase": 6.2, "apyReward": 1.1 },
-  { "symbol": "ANOM", "project": "realpool", "chain": "Ethereum", "tvlUsd": 2000000, "apyBase": 6.0, "apyReward": 0 },
-  { "symbol": "ANOM", "project": "degenfarm", "chain": "Solana", "tvlUsd": 900000000, "apyBase": 1500, "apyReward": 600 },
-  { "symbol": "USDC.E", "project": "aave-v3", "chain": "Arbitrum", "tvlUsd": 200000, "apyBase": 4.5, "apyReward": 0 },
-  { "symbol": "SMALL", "project": "newproto", "chain": "Base", "tvlUsd": 150000, "apyBase": 9.0, "apyReward": 0 },
-  { "symbol": "DUST", "project": "dustpool", "chain": "Solana", "tvlUsd": 50000, "apyBase": 12.0, "apyReward": 0 }
+  {
+    "symbol": "BIG",
+    "project": "aave-v3",
+    "chain": "Ethereum",
+    "tvlUsd": 500000000,
+    "apyBase": 4.1,
+    "apyReward": 0,
+    "pool": "big-aave-v3-0"
+  },
+  {
+    "symbol": "BIG",
+    "project": "compound-v3",
+    "chain": "Base",
+    "tvlUsd": 300000000,
+    "apyBase": 3.8,
+    "apyReward": 0.2,
+    "pool": "big-compound-v3-1"
+  },
+  {
+    "symbol": "MID",
+    "project": "curve",
+    "chain": "Ethereum",
+    "tvlUsd": 5000000,
+    "apyBase": 6.2,
+    "apyReward": 1.1,
+    "pool": "mid-curve-2"
+  },
+  {
+    "symbol": "ANOM",
+    "project": "realpool",
+    "chain": "Ethereum",
+    "tvlUsd": 2000000,
+    "apyBase": 6.0,
+    "apyReward": 0,
+    "pool": "anom-realpool-3"
+  },
+  {
+    "symbol": "ANOM",
+    "project": "degenfarm",
+    "chain": "Solana",
+    "tvlUsd": 900000000,
+    "apyBase": 1500,
+    "apyReward": 600,
+    "pool": "anom-degenfarm-4"
+  },
+  {
+    "symbol": "USDC.E",
+    "project": "aave-v3",
+    "chain": "Arbitrum",
+    "tvlUsd": 200000,
+    "apyBase": 4.5,
+    "apyReward": 0,
+    "pool": "usdc-e-aave-v3-5"
+  },
+  {
+    "symbol": "SMALL",
+    "project": "newproto",
+    "chain": "Base",
+    "tvlUsd": 150000,
+    "apyBase": 9.0,
+    "apyReward": 0,
+    "pool": "small-newproto-6"
+  },
+  {
+    "symbol": "DUST",
+    "project": "dustpool",
+    "chain": "Solana",
+    "tvlUsd": 50000,
+    "apyBase": 12.0,
+    "apyReward": 0,
+    "pool": "dust-dustpool-7"
+  }
 ]

--- a/test_token_pages.js
+++ b/test_token_pages.js
@@ -97,6 +97,18 @@ test('server-delivered meta description present', () => {
 test('links into the live app at ?token=<SYMBOL>', () => {
   assert.ok(html.includes('https://www.defi.garden/?token=BIG'), 'missing app deep link');
 });
+test('each pool row links to its detail page (/?pool=<id>)', () => {
+  const top = bySym['BIG'].pools[0];
+  assert.ok(top.pool, 'fixture pool missing an id');
+  assert.ok(html.includes(`href="https://www.defi.garden/?pool=${encodeURIComponent(top.pool)}"`),
+    'pool row not linked to its detail page');
+  assert.ok(html.includes('class="tp-pool-link"'), 'missing pool link class');
+});
+test('pool row falls back to the token app view when a pool has no id', () => {
+  const noId = gen.renderTokenPage({ symbol: 'X', slug: 'x', qualifyingCount: 1, totalTvl: 2e7,
+    pools: [{ project: 'aave', chain: 'Base', tvlUsd: 1e7, apyBase: 5, apyReward: 0 }] });
+  assert.ok(noId.includes('href="https://www.defi.garden/?token=X"'), 'missing fallback link');
+});
 test('renders >=1 real pool row with en-US formatted numbers', () => {
   assert.ok(/<td class="num">\d/.test(html), 'no formatted numeric cell');
   assert.ok(html.includes('%') && html.includes('$'), 'no APY/TVL');


### PR DESCRIPTION
Ships backlog item 029 per `product-loop-kit/specs/029.md` (human review: clicking a pool row on the live `/tokens/aave` page did nothing).

## What
- Each pool row's protocol cell now links to `${SITE_URL}/?pool=${p.pool}` — the rich pool-detail page (019) the app resolves via `pool.pool === urlParams.pool`. Falls back to the token app view when a pool has no id.
- Row hover + focus ring, tokens-only styling (no hardcoded hex), reduced-motion honored.
- Fixes the dead clicks **and** adds genuine internal links to useful pages (a real quality/interlinking signal) — not more templated filler.

## Verification
`node test_token_pages.js` 32/32 (2 new: row → `/?pool=<id>`, and no-id fallback); offline chain (`test_planner` 190 / `test_protocol_parsing` / `test_qualifier_fix` / `test_canonical` 24) exits 0. Trust rails/ranking/content otherwise unchanged.

## Not in scope (tracked separately)
This does **not** address the broader thin-content/low-quality indexing risk raised in review (bare templated tables across hundreds of tokens, 0.00%-APY pools leading the TVL sort). That's a strategy decision — differentiate content + be selective about which tokens get indexed — I'm raising with the human before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_