### PR TITLE
feat(030): token-page quality bar — only index tokens with real yield

### DIFF
--- a/generate-token-pages.js
+++ b/generate-token-pages.js
@@ -122,6 +122,10 @@ function rankTopTokens(pools, limit) {
   const records = [];
   byToken.forEach((rec, symbol) => {
     if (rec.qualifyingCount < MIN_QUALIFYING_POOLS) return; // 013 gate: skip thin tokens
+    // Quality bar (030, human directive): only generate/index a token page if
+    // at least one qualifying pool has a real (non-zero) yield — an all-0%-APY
+    // "DeFi Yields" page is useless and reads as thin/low-quality to Google.
+    if (!rec.pools.some(p => poolTotalApy(p) > 0)) return;
     rec.pools.sort((a, b) => (b.tvlUsd || 0) - (a.tvlUsd || 0));
     records.push({
       symbol,

--- a/product-loop-kit/specs/030-notes.md
+++ b/product-loop-kit/specs/030-notes.md
@@ -1,0 +1,4 @@
+# 030 build notes
+- One-line gate in rankTopTokens: drop tokens with no non-zero-yield qualifying pool. Fixture gained a ZERO token (two $30-50M pools, both 0% APY) -> dropped; 2 new assertions. 34 total.
+- Skips generation entirely (vs noindex) — cleanest "don't index": no page, no sitemap entry, no dead internal link. relatedFor consistent since it reads the gated ranked set.
+- Does NOT change ranking or the intro (0%-largest-pool look) — flagged as optional follow-up.

--- a/product-loop-kit/specs/030-pr.md
+++ b/product-loop-kit/specs/030-pr.md
@@ -1,0 +1,29 @@
+# 030 — PR explainer (HIGH tier): token-page quality bar (index only tokens with real yield)
+
+## Goal
+Prevent a thin-content / doorway-page quality hit. Bare templated tables across hundreds of tokens — especially "DeFi Yields" pages where every pool shows 0.00% — read as low-quality to Google and could suppress the whole domain. Human decision: index a token only if it has ≥1 qualifying pool AND ≥1 pool with a non-zero yield.
+
+## What changed
+`generate-token-pages.js`, one gate in `rankTopTokens` (after anomaly exclusion, the $100K floor, and the ≥1-pool gate): drop any token whose qualifying pools all have 0 total APY (`!rec.pools.some(p => poolTotalApy(p) > 0)`). Dropped tokens get no page, no sitemap entry, and no internal link (relatedFor + the sitemap read the same gated `ranked` set). Trust rails, floor, ranking — untouched.
+
+## Verification
+Verifier subagent: **PASS, HIGH, 3/3** — the all-0% fixture token (ZERO, $80M aggregate TVL) is dropped despite its high TVL (drop is APY-driven), every generated token has ≥1 non-zero-yield pool, anomaly/floor/ranking unchanged (ANOM keeps its page via its $2M@6% pool; the $900M@2100% pool still leaves no trace), scope clean. `test_token_pages.js` 34/34 + offline chain green.
+
+## Follow-up (separate PR)
+The 2,860 pages already committed to `tokens/` were generated before this gate — a regeneration-cleanup change is needed so the next CI run removes the now-dropped/stale pages (else they linger on disk). Tracked immediately after this.
+
+---
+
+## Quiz (answers base64 at the bottom)
+1. What makes a token page get dropped now?
+   A. Low TVL only  · B. All its qualifying pools show 0% yield  · C. It has too many pools
+2. Where is the new gate placed relative to the anomaly/floor filters?
+   A. Before them  · B. It replaces them  · C. After them — it only reads the already-filtered pools, changing none
+3. Does a dropped token still appear in the sitemap or a related-tokens nav?
+   A. Yes, in both  · B. No — sitemap + relatedFor use the same gated set  · C. Only the sitemap
+4. Why not just `noindex` the thin pages instead of skipping them?
+   A. noindex is broken  · B. It's required by law  · C. Skipping is cleaner — no page, no sitemap entry, no dead internal link
+5. Did this change the anomaly rail or the $100K floor?
+   A. Lowered the floor  · B. No — both untouched; only an APY>0 requirement was added on top  · C. Removed the anomaly rail
+
+<!-- answers: MTpCICAyOkMgIDM6QiAgNDpDICA1OkI= -->

--- a/product-loop-kit/specs/030.md
+++ b/product-loop-kit/specs/030.md
@@ -1,0 +1,19 @@
+# Spec 030: Token-page quality bar — only index tokens with real yield
+
+## Evidence
+Human review of the live /tokens/aave page + thin-content concern: bare templated tables across hundreds of tokens risk being read as doorway/low-quality pages by Google (2026 SEO: quality > quantity), which could drag the whole domain's quality signal (010's 22k crawled-not-indexed). Human decision: index tokens with >=1 pool AND >=1 non-zero yield — an all-0%-APY "DeFi Yields" page is useless and thin.
+
+## Change (generate-token-pages.js)
+- rankTopTokens: after the existing >=1-qualifying-pool gate, drop any token whose qualifying pools ALL have 0 total APY (`!rec.pools.some(p => poolTotalApy(p) > 0)`). Such tokens get no page (not generated, not in the sitemap, not linked) — so only genuinely useful yield pages are indexed.
+- Trust rails/ranking/floor/anomaly gate otherwise unchanged. Internal links stay consistent (relatedFor uses the same gated `ranked` set).
+
+## Acceptance criteria
+- [ ] A token whose qualifying pools are all 0% APY is dropped (no page); a token with >=1 non-zero-yield pool is kept
+- [ ] Every generated token has >=1 non-zero-yield pool
+- [ ] Anomaly/floor/ranking untouched; node test_token_pages.js + offline chain exit 0
+
+## Risk tier
+HIGH — SEO surface (what gets indexed). Verifier assigns.
+
+## Note
+Presentation polish (intro/table leading with the largest-by-TVL pool even when it's 0%) is a separate, optional follow-up — not in this gate.

--- a/test_fixtures/pools-sample.json
+++ b/test_fixtures/pools-sample.json
@@ -70,5 +70,23 @@
     "apyBase": 12.0,
     "apyReward": 0,
     "pool": "dust-dustpool-7"
+  },
+  {
+    "symbol": "ZERO",
+    "project": "aave-v3",
+    "chain": "Ethereum",
+    "tvlUsd": 50000000,
+    "apyBase": 0,
+    "apyReward": 0,
+    "pool": "zero-aave-v3-x"
+  },
+  {
+    "symbol": "ZERO",
+    "project": "compound-v3",
+    "chain": "Base",
+    "tvlUsd": 30000000,
+    "apyBase": 0,
+    "apyReward": 0,
+    "pool": "zero-compound-x"
   }
 ]

--- a/test_token_pages.js
+++ b/test_token_pages.js
@@ -42,6 +42,13 @@ test('newer/low-TVL token above the floor qualifies (SMALL @ $150K)', () => {
 test('token whose only pool is below $100K is dropped (DUST @ $50K)', () => {
   assert.ok(!bySym['DUST']);
 });
+test('token with pools but ALL 0% yield is dropped (030 quality bar — ZERO)', () => {
+  assert.ok(!bySym['ZERO'], 'an all-0%-APY token must not get an indexed page');
+});
+test('every generated token has >=1 pool with a real (non-zero) yield', () => {
+  ranked.forEach(r => assert.ok(r.pools.some(p => gen.poolTotalApy(p) > 0),
+    r.symbol + ' has no non-zero-yield pool'));
+});
 test('ranks by aggregate qualifying TVL desc', () => {
   assert.deepStrictEqual(ranked.map(r => r.symbol), ['BIG', 'MID', 'ANOM', 'USDC.E', 'SMALL']);
 });


### PR DESCRIPTION
Ships backlog item 030 per `product-loop-kit/specs/030.md` (human decision after reviewing the live thin pages).

## What
`generate-token-pages.js` — a quality gate in `rankTopTokens`: a token gets a page only if it has ≥1 qualifying pool **AND** ≥1 pool with a non-zero yield. All-0%-APY "DeFi Yields" pages (useless, thin, doorway-page risk) are dropped — no page, no sitemap entry, no internal link. Trust rails, floor, ranking untouched.

## Verification
Verifier subagent: **PASS, HIGH, 3/3** — the all-0% fixture token (ZERO, $80M TVL) is dropped despite high TVL (APY-driven), every generated token has real yield, anomaly/floor/ranking unchanged, scope clean. `test_token_pages.js` 34/34 + offline chain green. Explainer + quiz: `product-loop-kit/specs/030-pr.md`.

## ⚠️ Needs a follow-up (next PR)
`tokens/` on main already has ~2,860 pages generated before this gate. The next CI run must *clean* stale pages so the dropped ones are removed (not just skip regenerating them). That regeneration-cleanup fix comes immediately after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_