### PR TITLE
feat(031): token-page regeneration removes stale pages

### DIFF
--- a/generate-token-pages.js
+++ b/generate-token-pages.js
@@ -337,6 +337,14 @@ async function main() {
 
   const outDir = path.resolve(args.out);
   if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+  // Clean stale pages first so tokens dropped by the gate (030) / renamed slugs
+  // don't linger from a previous run. Only *.html is removed (never other files,
+  // and never if --out points at cwd) — the CI commit then stages the deletions.
+  if (outDir !== process.cwd()) {
+    fs.readdirSync(outDir).forEach(f => {
+      if (f.endsWith('.html')) fs.rmSync(path.join(outDir, f));
+    });
+  }
   ranked.forEach(rec => {
     fs.writeFileSync(path.join(outDir, `${rec.slug}.html`), renderTokenPage(rec, relatedFor(rec, ranked)));
   });

--- a/product-loop-kit/specs/031-notes.md
+++ b/product-loop-kit/specs/031-notes.md
@@ -1,0 +1,4 @@
+# 031 build notes
+- 4-line cleanup in main(): readdir out dir, rm *.html, before writing. cwd guard prevents nuking the repo if mispointed; only .html touched.
+- Demonstrated offline: run full fixture -> 5 pages; plant a stale page + rerun a 1-token fixture -> dir left with ONLY big.html. git add tokens stages deletions (modern git).
+- Pairs with 030 so the next CI run actually removes the ~2861 pre-gate pages that no longer qualify, and refreshes the rest with the 023/028/029 improvements.

--- a/product-loop-kit/specs/031-pr.md
+++ b/product-loop-kit/specs/031-pr.md
@@ -1,0 +1,26 @@
+# 031 — PR explainer (HIGH tier): regeneration removes stale token pages
+
+## Goal
+Make the 030 quality gate actually take effect on the ~2,861 pages already committed to `tokens/`. Regenerating only *writes* current pages; without a clean step, pages for tokens the gate now drops (all-0% yield), renamed slugs, or de-listed tokens would linger on disk and stay indexed.
+
+## What changed
+`generate-token-pages.js` main() — before writing the fresh set, remove existing `*.html` in the out dir. Two guards: only `.html` is deleted (never other files), and it skips clearing entirely if `--out` resolves to the current working directory (so a mistaken `--out .` can't nuke the repo). The CI commit's `git add tokens` stages the resulting deletions.
+
+## Verification
+Verifier subagent: **PASS, HIGH, 3/3** — demonstrated stale/dropped `.html` removed on regeneration; a planted `keep.txt`/`data.json` survived (only `.html` touched); `--out .` skipped clearing; page output byte-identical to main (`diff -rq` IDENTICAL); 34 assertions + offline chain green. Scope: 3 files.
+
+---
+
+## Quiz (answers base64 at the bottom)
+1. Why is this needed after 030?
+   A. To speed up CI  · B. Regeneration only writes pages; without cleanup the ~2,861 pre-gate pages (incl. now-dropped ones) linger  · C. To change ranking
+2. What does the clean step remove?
+   A. Everything in the repo  · B. The whole tokens dir always  · C. Only `*.html` in the out dir, before writing the fresh set
+3. What stops a mistaken `--out .` from deleting repo files?
+   A. Nothing  · B. A guard that skips clearing when outDir is the cwd  · C. A backup
+4. How do the deletions reach main?
+   A. A separate script  · B. Manually  · C. The CI commit's `git add tokens` stages them
+5. Did page content change?
+   A. Yes, new layout  · B. No — byte-identical; only a pre-write cleanup was added  · C. Ranking changed
+
+<!-- answers: MTpCICAyOkMgIDM6QiAgNDpDICA1OkI= -->

--- a/product-loop-kit/specs/031.md
+++ b/product-loop-kit/specs/031.md
@@ -1,0 +1,15 @@
+# Spec 031: Token-page regeneration removes stale pages
+
+## Evidence
+main already has ~2,861 committed token pages generated before the 030 quality gate (and before 023/028/029). Regenerating into tokens/ only WRITES current pages; without cleanup, pages for tokens dropped by 030 (all-0% yield), renamed slugs, or tokens that fell out of eligibility would linger on disk and stay indexed. The gate can't take effect on already-committed pages without this.
+
+## Change (generate-token-pages.js)
+- main() clears existing *.html in the out dir before writing the fresh set. Guards: only *.html removed (never other files); never runs if --out resolves to cwd (safety). The CI commit's `git add tokens` then stages the deletions.
+
+## Acceptance criteria
+- [ ] After regeneration, tokens/ contains exactly the current generated set — pages for dropped/renamed/removed tokens are deleted (demonstrated: stale + a 1-token rerun leaves only the current page)
+- [ ] Only *.html removed; refuses to clear when --out is cwd
+- [ ] node test_token_pages.js + offline chain exit 0
+
+## Risk tier
+HIGH — SEO pipeline (deletes generated pages). Verifier assigns.


### PR DESCRIPTION
Ships backlog item 031 per `product-loop-kit/specs/031.md`. Makes the 030 quality gate effective on the ~2,861 pages already committed to `tokens/`.

## What
`generate-token-pages.js` main() clears existing `*.html` in the out dir before writing the fresh set — so pages for tokens dropped by 030 (all-0% yield), renamed slugs, or de-listed tokens are removed, not left to linger and stay indexed. Guards: only `.html` deleted; skips clearing if `--out` is the cwd. The CI `git add tokens` stages the deletions.

## Verification
Verifier subagent: **PASS, HIGH, 3/3** — demonstrated stale/dropped `.html` removed; non-`.html` files survive; `--out .` skips clearing; page output byte-identical to main; 34 assertions + offline chain green. Explainer + quiz: `product-loop-kit/specs/031-pr.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_