### PR TITLE
feat(032): token-page gate requires VISIBLE non-zero APY (not 0.00%)

### DIFF
--- a/generate-token-pages.js
+++ b/generate-token-pages.js
@@ -122,10 +122,13 @@ function rankTopTokens(pools, limit) {
   const records = [];
   byToken.forEach((rec, symbol) => {
     if (rec.qualifyingCount < MIN_QUALIFYING_POOLS) return; // 013 gate: skip thin tokens
-    // Quality bar (030, human directive): only generate/index a token page if
-    // at least one qualifying pool has a real (non-zero) yield — an all-0%-APY
-    // "DeFi Yields" page is useless and reads as thin/low-quality to Google.
-    if (!rec.pools.some(p => poolTotalApy(p) > 0)) return;
+    // Quality bar (030 + 032): only generate/index a token page if at least one
+    // qualifying pool has a VISIBLE non-zero yield — i.e. its APY doesn't round
+    // to "0.00%" as displayed. A pool at e.g. 0.003% is technically > 0 but
+    // renders "0.00%", so an all-"0.00%" page (thin/low-quality to Google and
+    // useless to a saver) must still be dropped. Gate on the formatted value so
+    // it matches exactly what the page shows.
+    if (!rec.pools.some(p => formatApy(poolTotalApy(p)) !== '0.00%')) return;
     rec.pools.sort((a, b) => (b.tvlUsd || 0) - (a.tvlUsd || 0));
     records.push({
       symbol,

--- a/product-loop-kit/specs/032-notes.md
+++ b/product-loop-kit/specs/032-notes.md
@@ -1,0 +1,5 @@
+# 032 build notes
+- Gate changed from poolTotalApy(p) > 0 to formatApy(poolTotalApy(p)) !== '0.00%' — matches the displayed value, so no all-0.00% page survives.
+- Fixture gained TINY (0.003% APY, $2.72M TVL) -> dropped; 2 assertions updated/added (TINY drop + "visible non-zero" check). 35 total.
+- Caught by post-regen verification of the live pages (99/2132 all-0.00%), not by counts. The 031 cleanup will delete these 99 on the next CI run.
+- Threshold = "displays non-zero" (>= 0.01%). Easy to raise later if a higher yield bar is wanted.

--- a/product-loop-kit/specs/032-pr.md
+++ b/product-loop-kit/specs/032-pr.md
@@ -1,0 +1,29 @@
+# 032 — PR explainer (HIGH tier): gate on VISIBLE non-zero APY
+
+## Goal
+The first CI regen shipped 2,132 pages — but 99 showed "0.00%" on every row (e.g. behype: $2.72M pools, all 0.00% APY). Those are exactly the thin/low-quality pages the human flagged, and they slipped past the 030 gate.
+
+## Root cause
+030 gated on `poolTotalApy(p) > 0`. A pool at ~0.003% APY is technically > 0, but `formatApy` rounds it to "0.00%" — so the token qualified while its page displayed all zeros.
+
+## Fix
+`generate-token-pages.js` — gate on the DISPLAYED value: a token qualifies only if `rec.pools.some(p => formatApy(poolTotalApy(p)) !== '0.00%')`. Now the gate matches exactly what a visitor sees, so no all-"0.00%" page can survive. Anomaly rail, $100K floor, ranking untouched.
+
+## Verification
+Verifier subagent: **PASS, HIGH, 4/4** — TINY (0.003%, $2.72M) dropped despite qualifying on TVL; every generated page has ≥1 non-0.00% APY; ANOM kept via its 6% pool; $900M@2100% still leaves no trace; scope clean; `test_token_pages.js` 35/35 + offline chain green. The 99 stale pages get removed by the 031 cleanup on the next CI run.
+
+---
+
+## Quiz (answers base64 at the bottom)
+1. Why did 99 pages show all "0.00%" despite the 030 gate?
+   A. A CSS bug  · B. 030 checked APY>0, but ~0.003% pools pass that yet display "0.00%"  · C. The API was down
+2. What does the new gate compare?
+   A. TVL  · B. Raw APY > 0  · C. The formatted APY string against "0.00%"
+3. Is a token at 0.003% APY now kept or dropped?
+   A. Kept  · B. Dropped — it displays 0.00%  · C. Depends on TVL
+4. Did the anomaly rail or $100K floor change?
+   A. Floor lowered  · B. Anomaly rail removed  · C. Neither — only the yield check tightened
+5. How do the 99 bad pages get removed from main?
+   A. Manually  · B. The 031 cleanup deletes them on the next CI regen  · C. They stay
+
+<!-- answers: MTpCICAyOkMgIDM6QiAgNDpDICA1OkI= -->

--- a/product-loop-kit/specs/032.md
+++ b/product-loop-kit/specs/032.md
@@ -1,0 +1,16 @@
+# Spec 032: Token-page yield gate — require VISIBLE non-zero APY
+
+## Evidence
+The first CI regen (commit a28c60f) produced 2,132 pages, but 99 of them show "0.00%" on EVERY row (e.g. tokens/behype.html: $2.72M/$333K/$102K pools, all 0.00% APY). Root cause: the 030 gate checks poolTotalApy > 0, but a pool at ~0.003% is technically > 0 yet formatApy renders "0.00%". Those pages are exactly the thin/low-quality "DeFi Yields" pages the human flagged.
+
+## Change (generate-token-pages.js)
+- Tighten the 030 gate: a token qualifies only if ≥1 pool's DISPLAYED APY is not "0.00%" — `rec.pools.some(p => formatApy(poolTotalApy(p)) !== '0.00%')`. Gates on the formatted value so it matches exactly what the page shows; drops the all-0.00% pages.
+
+## Acceptance criteria
+- [ ] A token whose best yield rounds to 0.00% (e.g. 0.003%) is dropped; a token with a visible yield (≥0.01%) is kept
+- [ ] Every generated token shows ≥1 non-"0.00%" APY row
+- [ ] Trust rails/floor/ranking untouched; node test_token_pages.js + offline chain exit 0
+- [ ] After the next CI regen: zero pages with all-0.00% APY
+
+## Risk tier
+HIGH — SEO surface (what gets indexed). Verifier assigns.

--- a/test_fixtures/pools-sample.json
+++ b/test_fixtures/pools-sample.json
@@ -88,5 +88,14 @@
     "apyBase": 0,
     "apyReward": 0,
     "pool": "zero-compound-x"
+  },
+  {
+    "symbol": "TINY",
+    "project": "somelend",
+    "chain": "Ethereum",
+    "tvlUsd": 2720000,
+    "apyBase": 0.003,
+    "apyReward": 0,
+    "pool": "tiny-somelend-y"
   }
 ]

--- a/test_token_pages.js
+++ b/test_token_pages.js
@@ -45,9 +45,12 @@ test('token whose only pool is below $100K is dropped (DUST @ $50K)', () => {
 test('token with pools but ALL 0% yield is dropped (030 quality bar — ZERO)', () => {
   assert.ok(!bySym['ZERO'], 'an all-0%-APY token must not get an indexed page');
 });
-test('every generated token has >=1 pool with a real (non-zero) yield', () => {
-  ranked.forEach(r => assert.ok(r.pools.some(p => gen.poolTotalApy(p) > 0),
-    r.symbol + ' has no non-zero-yield pool'));
+test('token whose best yield rounds to 0.00% is dropped (032 — TINY @ 0.003%)', () => {
+  assert.ok(!bySym['TINY'], 'a token whose APY displays 0.00% must not get an indexed page');
+});
+test('every generated token has >=1 pool with a VISIBLE non-zero yield (not 0.00%)', () => {
+  ranked.forEach(r => assert.ok(r.pools.some(p => gen.formatApy(gen.poolTotalApy(p)) !== '0.00%'),
+    r.symbol + ' shows all 0.00% APY'));
 });
 test('ranks by aggregate qualifying TVL desc', () => {
   assert.deepStrictEqual(ranked.map(r => r.symbol), ['BIG', 'MID', 'ANOM', 'USDC.E', 'SMALL']);


### PR DESCRIPTION
Fixes a hole in the 030 gate found by verifying the live pages: the first CI regen shipped 2,132 pages, but **99 showed "0.00%" on every row** (e.g. behype: $2.72M pools, all 0.00%).

## Root cause + fix
030 gated on `poolTotalApy > 0`. A pool at ~0.003% is technically `> 0` but `formatApy` renders it "0.00%". Now the gate compares the **displayed** value: a token qualifies only if `rec.pools.some(p => formatApy(poolTotalApy(p)) !== '0.00%')` — so no all-"0.00%" page survives. Anomaly rail, $100K floor, ranking untouched.

## Verification
Verifier subagent: **PASS, HIGH, 4/4** — TINY (0.003%, $2.72M) dropped despite qualifying on TVL; every generated page has ≥1 non-0.00% APY; ANOM kept via its 6% pool; scope clean; `test_token_pages.js` 35/35 + offline chain green. Explainer + quiz: `product-loop-kit/specs/032-pr.md`.

## Next CI run cleans up
The 99 stale all-0.00% pages get deleted by the 031 cleanup on the next "Update Sitemap" run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_