### PR TITLE
feat(033): yield gate checks the DISPLAYED pools (truncation fix)

### DIFF
--- a/generate-token-pages.js
+++ b/generate-token-pages.js
@@ -122,20 +122,20 @@ function rankTopTokens(pools, limit) {
   const records = [];
   byToken.forEach((rec, symbol) => {
     if (rec.qualifyingCount < MIN_QUALIFYING_POOLS) return; // 013 gate: skip thin tokens
-    // Quality bar (030 + 032): only generate/index a token page if at least one
-    // qualifying pool has a VISIBLE non-zero yield — i.e. its APY doesn't round
-    // to "0.00%" as displayed. A pool at e.g. 0.003% is technically > 0 but
-    // renders "0.00%", so an all-"0.00%" page (thin/low-quality to Google and
-    // useless to a saver) must still be dropped. Gate on the formatted value so
-    // it matches exactly what the page shows.
-    if (!rec.pools.some(p => formatApy(poolTotalApy(p)) !== '0.00%')) return;
     rec.pools.sort((a, b) => (b.tvlUsd || 0) - (a.tvlUsd || 0));
+    const shown = rec.pools.slice(0, POOLS_PER_PAGE); // top-N by TVL — what the page displays
+    // Quality bar (030 / 032 / 033): the DISPLAYED table must show at least one
+    // VISIBLE non-zero yield — an APY that doesn't round to "0.00%". Gate on the
+    // SHOWN slice, not all pools: a pool at 0.003% renders "0.00%" (032), and a
+    // yield-bearing pool ranked beyond POOLS_PER_PAGE isn't on the page at all
+    // (033) — either way an all-"0.00%" table is thin/low-quality and dropped.
+    if (!shown.some(p => formatApy(poolTotalApy(p)) !== '0.00%')) return;
     records.push({
       symbol,
       slug: tokenSlug(symbol),
       totalTvl: rec.totalTvl,
       qualifyingCount: rec.qualifyingCount,
-      pools: rec.pools.slice(0, POOLS_PER_PAGE)
+      pools: shown
     });
   });
 

--- a/product-loop-kit/specs/033-notes.md
+++ b/product-loop-kit/specs/033-notes.md
@@ -1,0 +1,4 @@
+# 033 build notes
+- Moved the sort+slice BEFORE the yield gate and gated on the shown slice (rec.pools.slice(0,POOLS_PER_PAGE)). Now the gate matches exactly the rendered table.
+- Fixture: TRUNC = 8x 0%-APY high-TVL pools + 1x 5% low-TVL pool -> displayed top-8 all 0.00% -> dropped. Passes 032's all-pools gate, so it's the truncation regression. +9 fixture rows, 2 assertions (TRUNC drop + shown-table check). 36 total.
+- Respects "best tvl first" (human): ordering unchanged; only drops tokens whose TVL-top-8 show no yield. The 4 live pages get removed by 031 cleanup on the next CI run.

--- a/product-loop-kit/specs/033-pr.md
+++ b/product-loop-kit/specs/033-pr.md
@@ -1,0 +1,29 @@
+# 033 — PR explainer (HIGH tier): yield gate checks the DISPLAYED pools
+
+## Goal
+After 032, 4 pages still showed "0.00%" on every row (guld/pt/st/sta). Close the last hole so no all-zero table can be indexed — while keeping TVL-first ordering (human's call).
+
+## Root cause
+032 gated on `rec.pools.some(...)` over ALL qualifying pools, but a page renders only the top-`POOLS_PER_PAGE` (8) by TVL. A token whose top-8-by-TVL are all 0.00%, with a yield-bearing pool ranked #9+, passed the gate yet displayed an all-"0.00%" table.
+
+## Fix
+`generate-token-pages.js` — sort by TVL, slice to `shown = top 8`, THEN gate: keep only if `shown.some(p => formatApy(poolTotalApy(p)) !== '0.00%')`. The gate now reads exactly the rendered table. Ordering unchanged (still TVL desc); it just drops tokens whose visible table would be all zeros.
+
+## Verification
+Verifier subagent: **PASS, HIGH, 4/4** — TRUNC (8×0% high-TVL + 1×5% at rank 9) dropped; every generated page shows ≥1 non-0.00% APY; ANOM kept via its 6% pool ($900M@2100% leaves no trace); DUST dropped for floor; token ranking unchanged; `test_token_pages.js` 36/36 + offline chain green. The 4 live pages get removed by the 031 cleanup on the next CI run.
+
+---
+
+## Quiz (answers base64 at the bottom)
+1. Why did 4 pages still show all "0.00%" after 032?
+   A. Cleanup failed  · B. 032 checked all pools, but the page shows only the top-8 by TVL; a yield pool at rank 9+ passed the gate  · C. The API changed
+2. What set does the gate check now?
+   A. All qualifying pools  · B. A random sample  · C. The displayed slice (top POOLS_PER_PAGE by TVL)
+3. Did this change the table's ordering?
+   A. Now yield-first  · B. Now alphabetical  · C. No — still TVL-first; only the gate moved after the slice
+4. What happens to a token whose top-8-by-TVL are all 0.00%?
+   A. Shown with a warning  · B. Dropped (no page), even if a yield pool exists at rank 9+  · C. Re-sorted by APY
+5. How do the 4 live pages get removed?
+   A. Manually  · B. The 031 cleanup deletes them on the next CI regen  · C. They stay
+
+<!-- answers: MTpCICAyOkMgIDM6QyAgNDpCICA1OkI= -->

--- a/product-loop-kit/specs/033.md
+++ b/product-loop-kit/specs/033.md
@@ -1,0 +1,16 @@
+# Spec 033: Yield gate must check the DISPLAYED pools (truncation fix)
+
+## Evidence
+After the 032 regen (2,032 pages), 4 pages still showed "0.00%" on every row (tokens/guld,pt,st,sta). Root cause: 032 gated on `rec.pools.some(...)` over ALL qualifying pools, but the page displays only the top-POOLS_PER_PAGE (8) by TVL. A token whose top-8-by-TVL are all 0.00% but has a yield-bearing pool ranked #9+ passes the gate yet renders an all-"0.00%" table.
+
+## Change (generate-token-pages.js)
+- Sort by TVL, slice to the shown set (top POOLS_PER_PAGE), THEN gate: keep only if the SHOWN slice has ≥1 pool whose displayed APY != "0.00%". Respects TVL-first ordering (human choice) — just drops tokens whose visible table would be all zeros.
+
+## Acceptance criteria
+- [ ] A token whose displayed (top-8-by-TVL) pools are all 0.00%, with a yield pool beyond rank 8, is dropped (TRUNC fixture)
+- [ ] Every generated page's rendered table shows ≥1 non-"0.00%" APY
+- [ ] TVL-first ordering unchanged; trust rails/floor untouched; node test_token_pages.js + offline chain exit 0
+- [ ] After next CI regen: zero all-0.00% pages
+
+## Risk tier
+HIGH — SEO indexing surface. Verifier assigns.

--- a/test_fixtures/pools-sample.json
+++ b/test_fixtures/pools-sample.json
@@ -97,5 +97,86 @@
     "apyBase": 0.003,
     "apyReward": 0,
     "pool": "tiny-somelend-y"
+  },
+  {
+    "symbol": "TRUNC",
+    "project": "zpool0",
+    "chain": "Ethereum",
+    "tvlUsd": 20000000,
+    "apyBase": 0,
+    "apyReward": 0,
+    "pool": "trunc-z0"
+  },
+  {
+    "symbol": "TRUNC",
+    "project": "zpool1",
+    "chain": "Ethereum",
+    "tvlUsd": 19000000,
+    "apyBase": 0,
+    "apyReward": 0,
+    "pool": "trunc-z1"
+  },
+  {
+    "symbol": "TRUNC",
+    "project": "zpool2",
+    "chain": "Ethereum",
+    "tvlUsd": 18000000,
+    "apyBase": 0,
+    "apyReward": 0,
+    "pool": "trunc-z2"
+  },
+  {
+    "symbol": "TRUNC",
+    "project": "zpool3",
+    "chain": "Ethereum",
+    "tvlUsd": 17000000,
+    "apyBase": 0,
+    "apyReward": 0,
+    "pool": "trunc-z3"
+  },
+  {
+    "symbol": "TRUNC",
+    "project": "zpool4",
+    "chain": "Ethereum",
+    "tvlUsd": 16000000,
+    "apyBase": 0,
+    "apyReward": 0,
+    "pool": "trunc-z4"
+  },
+  {
+    "symbol": "TRUNC",
+    "project": "zpool5",
+    "chain": "Ethereum",
+    "tvlUsd": 15000000,
+    "apyBase": 0,
+    "apyReward": 0,
+    "pool": "trunc-z5"
+  },
+  {
+    "symbol": "TRUNC",
+    "project": "zpool6",
+    "chain": "Ethereum",
+    "tvlUsd": 14000000,
+    "apyBase": 0,
+    "apyReward": 0,
+    "pool": "trunc-z6"
+  },
+  {
+    "symbol": "TRUNC",
+    "project": "zpool7",
+    "chain": "Ethereum",
+    "tvlUsd": 13000000,
+    "apyBase": 0,
+    "apyReward": 0,
+    "pool": "trunc-z7"
+  },
+  {
+    "symbol": "TRUNC",
+    "project": "yieldpool",
+    "chain": "Base",
+    "tvlUsd": 200000,
+    "apyBase": 5.0,
+    "apyReward": 0,
+    "pool": "trunc-yield"
   }
 ]

--- a/test_token_pages.js
+++ b/test_token_pages.js
@@ -48,9 +48,13 @@ test('token with pools but ALL 0% yield is dropped (030 quality bar — ZERO)', 
 test('token whose best yield rounds to 0.00% is dropped (032 — TINY @ 0.003%)', () => {
   assert.ok(!bySym['TINY'], 'a token whose APY displays 0.00% must not get an indexed page');
 });
-test('every generated token has >=1 pool with a VISIBLE non-zero yield (not 0.00%)', () => {
+test('token whose yield pool is beyond POOLS_PER_PAGE is dropped (033 — TRUNC)', () => {
+  // TRUNC's top-8-by-TVL are all 0%; its 5% pool is #9 (not shown) -> displayed table all 0.00%
+  assert.ok(!bySym['TRUNC'], 'a token whose displayed table is all 0.00% must not get an indexed page');
+});
+test('every generated token DISPLAYS >=1 visible non-zero yield (gate matches the shown table)', () => {
   ranked.forEach(r => assert.ok(r.pools.some(p => gen.formatApy(gen.poolTotalApy(p)) !== '0.00%'),
-    r.symbol + ' shows all 0.00% APY'));
+    r.symbol + ' shows all 0.00% APY in its rendered table'));
 });
 test('ranks by aggregate qualifying TVL desc', () => {
   assert.deepStrictEqual(ranked.map(r => r.symbol), ['BIG', 'MID', 'ANOM', 'USDC.E', 'SMALL']);


### PR DESCRIPTION
Closes the last all-zero-table hole. After 032, 4 pages still showed "0.00%" on every row (guld/pt/st/sta).

## Root cause + fix
032 gated on `rec.pools.some(...)` over ALL qualifying pools, but a page renders only the top-8 by TVL. A token whose top-8-by-TVL are all 0.00%, with a yield pool ranked #9+, passed the gate yet displayed an all-"0.00%" table. Now: sort by TVL → slice to the shown top-8 → gate on that slice. The gate matches exactly what's rendered. **TVL-first ordering unchanged** (per your call).

## Verification
Verifier subagent: **PASS, HIGH, 4/4** — TRUNC (8×0% high-TVL + 1×5% at rank 9) dropped; every generated page shows ≥1 non-0.00% APY; ANOM kept via its 6% pool; ranking unchanged; `test_token_pages.js` 36/36 + offline chain green. Explainer + quiz: `product-loop-kit/specs/033-pr.md`.

## Next CI run
The 4 live pages get deleted by the 031 cleanup on the next "Update Sitemap" run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_