### PR TITLE
feat(034): pool-detail projection + CTA reflect the calculator's investment amount

### DIFF
--- a/PoolDetail.js
+++ b/PoolDetail.js
@@ -180,14 +180,16 @@ function PoolDetail({
   const gardenPersona = riskAssessment.score <= 25 ? 'stable' : riskAssessment.score <= 50 ? 'rwa' : 'degen';
   const isAnomalous = totalApy > APY_SANITY_LIMIT_LOCAL;
   const applyDegenHaircut = gardenPersona === 'degen';
-  const PROJECTION_MONTHLY = 200;
   const PROJECTION_YEARS = 5;
   const projectionApy = applyDegenHaircut ? totalApy / 3 : totalApy;
-  const projectionAmount = _futureValue(PROJECTION_MONTHLY, projectionApy, PROJECTION_YEARS);
-  // Prefill the planner horizon (years) too, so the recipient lands on exactly
-  // this pool's projection (025). The deep link never carries the pool's APY —
-  // the planner computes from its own blended, sanity-capped rate.
-  const gardenThisPoolHref = `plan.html?goal=retirement&pace=${gardenPersona}&monthly=${PROJECTION_MONTHLY}&years=${PROJECTION_YEARS}`;
+  // Projection is tied to the calculator's investment amount (lump sum, default
+  // $1,000) so the number below AND the CTA react to what the user selects.
+  // Lump-sum compound growth: principal * (1 + r)^years.
+  const projectionAmount = investmentAmount * Math.pow(1 + projectionApy / 100, PROJECTION_YEARS);
+  // Prefill the planner with the SAME lump sum + horizon so it lands on exactly
+  // this projection (as capital, matching the calculator). The deep link never
+  // carries the pool's APY — the planner computes from its own sanity-capped rate.
+  const gardenThisPoolHref = `plan.html?goal=retirement&pace=${gardenPersona}&capital=${Math.round(investmentAmount)}&fm=capital&years=${PROJECTION_YEARS}`;
   // Concrete CTA (025): show the projected outcome ON the button — but NEVER for
   // an anomalous pool (trust rail: anomalous rates are flagged, never hyped).
   const showConcreteCta = !isAnomalous;
@@ -478,7 +480,7 @@ function PoolDetail({
             onClick: () => {
               if (typeof Analytics !== 'undefined') {
                 Analytics.trackPoolClick(pool, 'garden_cta', {
-                  investmentAmount: PROJECTION_MONTHLY,
+                  investmentAmount: Math.round(investmentAmount),
                   projectionYears: PROJECTION_YEARS,
                   ctaVariant: showConcreteCta ? 'concrete' : 'generic'
                 });
@@ -671,8 +673,8 @@ function PoolDetail({
           color: 'var(--color-text)',
           lineHeight: '1.4'
         }
-      }, t ? t('projectionBody', PROJECTION_MONTHLY, PROJECTION_YEARS, projectionAmount) :
-        `$${PROJECTION_MONTHLY}/mo in this pool grows to ~${_formatUsd(projectionAmount, 0)} in ${PROJECTION_YEARS}y at current rates.`),
+      }, t ? t('projectionBody', investmentAmount, PROJECTION_YEARS, projectionAmount) :
+        `$${Number(investmentAmount || 0).toLocaleString('en-US')} in this pool grows to ~${_formatUsd(projectionAmount, 0)} in ${PROJECTION_YEARS}y at current rates.`),
       applyDegenHaircut && React.createElement('div', { className: 'calc-warning' },
         t ? t('poolDegenHaircutNote', _formatApy(totalApy)) : `Projected at ⅓ haircut (${_formatApy(totalApy)} headline) — farm rates decay. Active management required.`
       ),

--- a/product-loop-kit/specs/034-notes.md
+++ b/product-loop-kit/specs/034-notes.md
@@ -1,0 +1,5 @@
+# 034 build notes
+- Root cause: 025 used PROJECTION_MONTHLY=$200 (monthly annuity via _futureValue), never reading investmentAmount. Switched to lump-sum compound growth of investmentAmount (default 1000).
+- projectionBody signature monthly->principal; EN+KO updated (dropped "/mo" and KO "월"). Verified both render: "$1,000 ... ~$1,268 in 5y".
+- Deep link now capital path (capital+fm=capital+years) so the planner prefills the same lump sum the user selected.
+- Reactive by construction (investmentAmount is state; projectionAmount computed in render). Browser eyeball still worth doing (change the amount, watch CTA+projection update) — not runnable here.

--- a/product-loop-kit/specs/034-pr.md
+++ b/product-loop-kit/specs/034-pr.md
@@ -1,0 +1,29 @@
+# 034 — PR explainer (HIGH tier): projection/CTA tied to the calculator amount
+
+## Goal
+On a pool-detail page, the "Garden this pool → ~$X in 5y" CTA and the "The Long Game" projection showed a number the user couldn't affect — a hardcoded $200/mo — instead of reflecting the investment amount they set in the calculator lower on the page (default $1,000).
+
+## What changed (PoolDetail.js + translations.js)
+- `projectionAmount = investmentAmount * (1 + projectionApy/100)^PROJECTION_YEARS` — lump-sum compound growth of the calculator's `investmentAmount` state (default 1000). Computed in render, so it updates live as the user changes the amount.
+- Projection copy is now lump-sum framed: "$1,000 in this pool grows to ~$1,268 in 5y at current rates." (EN + KO).
+- The CTA uses the same reactive number; the anomaly gate (generic CTA for >1000% pools) and the degen ⅓ haircut are preserved.
+- The "Garden this pool" deep link carries the same lump sum as capital: `capital=<amount>&fm=capital&years=5`, so the planner opens prefilled with what the user selected.
+
+## Verification
+Verifier subagent: **PASS, HIGH, 4/4** — projection reads `investmentAmount`, CTA + body share it, haircut + anomaly gate intact, deep link is the capital path, EN+KO both render ("$1,000 … ~$1,268 in 5y"), scope = 4 files, offline chain green. Residual: browser eyeball that changing the amount updates the number live (reactive by construction).
+
+---
+
+## Quiz (answers base64 at the bottom)
+1. What was wrong with the old CTA number?
+   A. Wrong currency  · B. Hardcoded $200/mo, disconnected from the calculator amount  · C. It was missing
+2. What does the projection use now?
+   A. Pool TVL  · B. A fixed $200  · C. Compound growth of the calculator's investmentAmount (default $1,000)
+3. Is the number reactive to the user's selection?
+   A. No, static  · B. Yes — investmentAmount is state, projectionAmount is computed in render  · C. Only after reload
+4. What does the deep link carry now?
+   A. monthly=200  · B. The pool's APY  · C. capital=<amount>&fm=capital&years=5
+5. Were the anomaly gate and degen haircut kept?
+   A. Removed  · B. Both preserved  · C. Only the haircut
+
+<!-- answers: MTpCICAyOkMgIDM6QiAgNDpDICA1OkI= -->

--- a/product-loop-kit/specs/034.md
+++ b/product-loop-kit/specs/034.md
@@ -1,0 +1,20 @@
+# Spec 034: Pool-detail projection/CTA must reflect the calculator's investment amount
+
+## Evidence
+Human review of a pool-detail page: the "Garden this pool → ~$X in 5y" CTA (025) and the "The Long Game" projection used a hardcoded PROJECTION_MONTHLY=$200/mo — disconnected from the calculator's investment amount (PoolDetail.js:36 `investmentAmount`, default $1,000) that the user actually sets lower on the page. So the number was wrong/static.
+
+## Change (PoolDetail.js + translations.js)
+- Tie the projection to `investmentAmount` (lump sum, default $1,000) as compound growth: `investmentAmount * (1 + projectionApy/100)^PROJECTION_YEARS`. Reactive — updates as the user changes the calculator amount.
+- projectionBody copy: "$<amount> in this pool grows to ~$<future> in 5y at current rates." (lump-sum framing, not "/mo"). EN + KO.
+- CTA "~$X in 5y" uses the same reactive projectionAmount; anomaly-gate (025) unchanged.
+- Deep link carries the same lump sum as capital: `plan.html?goal=retirement&pace=<persona>&capital=<investmentAmount>&fm=capital&years=5` — planner opens prefilled with the user's amount.
+- garden_cta instrument sends the real investmentAmount. Degen ⅓ haircut preserved.
+
+## Acceptance criteria
+- [ ] Projection + CTA number = compound growth of the calculator's investmentAmount (default $1,000) at the pool's (haircut-adjusted) APY over 5y; changing the amount changes both
+- [ ] Copy is lump-sum framed, EN + KO both render; en-US formatting
+- [ ] Deep link carries capital=<amount>&fm=capital&years=5; anomaly CTA gate (025) intact; degen haircut intact
+- [ ] node --check clean; offline test chain exits 0
+
+## Risk tier
+HIGH — user-facing render path (pool-detail = SEO lander → north star). Verifier assigns.

--- a/translations.js
+++ b/translations.js
@@ -88,7 +88,7 @@ const translations = {
 
     // Honest mini-projection (pool-detail)
     projectionHeading: "The Long Game",
-    projectionBody: (monthly, years, amount) => `$${Number(monthly || 0).toLocaleString('en-US')}/mo in this pool grows to ~$${Number(amount || 0).toLocaleString('en-US', { maximumFractionDigits: 0 })} in ${years}y at current rates.`,
+    projectionBody: (principal, years, amount) => `$${Number(principal || 0).toLocaleString('en-US')} in this pool grows to ~$${Number(amount || 0).toLocaleString('en-US', { maximumFractionDigits: 0 })} in ${years}y at current rates.`,
     gardenThisPoolCtaConcrete: (amount, years) => `Garden this pool → ~$${Number(amount || 0).toLocaleString('en-US', { maximumFractionDigits: 0 })} in ${years}y`,
     poolDegenHaircutNote: (headline) => `Projected at ⅓ haircut (${headline} headline) — farm rates decay. Active management required.`,
 
@@ -588,7 +588,7 @@ const translations = {
 
     // Honest mini-projection (pool-detail)
     projectionHeading: "장기적으로 보면",
-    projectionBody: (monthly, years, amount) => `이 풀에 월 ${formatKoreanCurrency(monthly)}을 넣으면 ${years}년 후 현재 수익률 기준 약 ${formatKoreanCurrency(Number(amount || 0))}이 됩니다.`,
+    projectionBody: (principal, years, amount) => `이 풀에 ${formatKoreanCurrency(principal)}을 넣으면 ${years}년 후 현재 수익률 기준 약 ${formatKoreanCurrency(Number(amount || 0))}이 됩니다.`,
     gardenThisPoolCtaConcrete: (amount, years) => `이 풀 가든하기 → ${years}년 후 약 ${formatKoreanCurrency(Number(amount || 0))}`,
     poolDegenHaircutNote: (headline) => `⅓ 할인 적용 (헤드라인 ${headline}) — 팜 수익률은 빠르게 감소. 적극적 관리 필요.`,
 


### PR DESCRIPTION
Fixes the "~$X in 5y" number the human flagged: the "Garden this pool" CTA (025) and the "The Long Game" projection used a hardcoded $200/mo, disconnected from the calculator's investment amount lower on the page (default $1,000).

## What
- `projectionAmount` = lump-sum compound growth of `investmentAmount` (calculator state, default $1,000) at the pool's haircut-adjusted APY over 5y — computed in render, so it updates **live** as the user changes the amount.
- Projection copy is lump-sum framed now: "$1,000 in this pool grows to ~$1,268 in 5y at current rates." (EN + KO).
- CTA uses the same reactive number; anomaly gate (generic CTA for >1000% pools) + degen ⅓ haircut preserved.
- Deep link carries the same lump sum as capital: `capital=<amount>&fm=capital&years=5` → planner opens prefilled with what the user selected.

## Verification
Verifier subagent: **PASS, HIGH, 4/4** — projection reads `investmentAmount`; CTA + body share it; haircut + anomaly gate intact; capital-path deep link; EN+KO both render; scope = 4 files; offline chain green. Explainer + quiz: `product-loop-kit/specs/034-pr.md`.

Residual (human): eyeball in a browser that changing the calculator amount updates the CTA + projection live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnucwjgH3oz8NJSbWPYDG)_