### PR TITLE
feat(seo-aeo): upgrade agentic discovery, WebMCP tools, and llms.txt protocol specs

### DIFF
--- a/.well-known/mcp.json
+++ b/.well-known/mcp.json
@@ -2,9 +2,14 @@
   "$schema": "https://modelcontextprotocol.org/schemas/mcp-server-card-v1.json",
   "serverInfo": {
     "name": "DeFi Garden MCP Server",
-    "version": "1.0.0"
+    "version": "1.1.0",
+    "description": "Yield discovery and deterministic trust rails engine for AI agents and autonomous onchain wallets."
   },
   "transports": [
+    {
+      "type": "streamable-http",
+      "url": "https://www.defi.garden/mcp"
+    },
     {
       "type": "sse",
       "url": "https://www.defi.garden/api/mcp"
@@ -19,5 +24,52 @@
       "list": true,
       "get": true
     }
-  }
+  },
+  "tools": [
+    {
+      "name": "find_pools",
+      "description": "Find curated DeFi yield pools filtered by deterministic trust rails (TVL >= $100k, APY <= 1000%).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "token": { "type": "string", "description": "Token symbol (e.g. USDC, ETH, SOL)" },
+          "chain": { "type": "string", "description": "Blockchain name (e.g. Ethereum, Base, Solana)" },
+          "poolTypes": { "type": "string", "description": "Pool type: Lending, Staking, LP/DEX, Yield Farming" },
+          "minTvl": { "type": "number", "description": "Minimum TVL in USD" },
+          "minApy": { "type": "number", "description": "Minimum APY percentage" }
+        }
+      }
+    },
+    {
+      "name": "get_pool",
+      "description": "Retrieve detailed metadata and APY breakdown for a specific pool UUID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "poolId": { "type": "string", "description": "Pool UUID" }
+        },
+        "required": ["poolId"]
+      }
+    },
+    {
+      "name": "forever_number",
+      "description": "Calculate capital whose yield indefinitely covers a recurring monthly/annual bill or compute cost.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "monthlyExpense": { "type": "number", "description": "Monthly recurring bill or compute cost in USD" },
+          "blendedApy": { "type": "number", "description": "Expected blended APY percentage (default: 4.0)" }
+        },
+        "required": ["monthlyExpense"]
+      }
+    },
+    {
+      "name": "explain_rails",
+      "description": "Returns deterministic trust rails rules (TVL >= $100k, APY cap <= 1000%, anomaly demotion).",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  ]
 }

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -2,9 +2,14 @@
   "$schema": "https://modelcontextprotocol.org/schemas/mcp-server-card-v1.json",
   "serverInfo": {
     "name": "DeFi Garden MCP Server",
-    "version": "1.0.0"
+    "version": "1.1.0",
+    "description": "Yield discovery and deterministic trust rails engine for AI agents and autonomous onchain wallets."
   },
   "transports": [
+    {
+      "type": "streamable-http",
+      "url": "https://www.defi.garden/mcp"
+    },
     {
       "type": "sse",
       "url": "https://www.defi.garden/api/mcp"
@@ -19,5 +24,52 @@
       "list": true,
       "get": true
     }
-  }
+  },
+  "tools": [
+    {
+      "name": "find_pools",
+      "description": "Find curated DeFi yield pools filtered by deterministic trust rails (TVL >= $100k, APY <= 1000%).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "token": { "type": "string", "description": "Token symbol (e.g. USDC, ETH, SOL)" },
+          "chain": { "type": "string", "description": "Blockchain name (e.g. Ethereum, Base, Solana)" },
+          "poolTypes": { "type": "string", "description": "Pool type: Lending, Staking, LP/DEX, Yield Farming" },
+          "minTvl": { "type": "number", "description": "Minimum TVL in USD" },
+          "minApy": { "type": "number", "description": "Minimum APY percentage" }
+        }
+      }
+    },
+    {
+      "name": "get_pool",
+      "description": "Retrieve detailed metadata and APY breakdown for a specific pool UUID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "poolId": { "type": "string", "description": "Pool UUID" }
+        },
+        "required": ["poolId"]
+      }
+    },
+    {
+      "name": "forever_number",
+      "description": "Calculate capital whose yield indefinitely covers a recurring monthly/annual bill or compute cost.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "monthlyExpense": { "type": "number", "description": "Monthly recurring bill or compute cost in USD" },
+          "blendedApy": { "type": "number", "description": "Expected blended APY percentage (default: 4.0)" }
+        },
+        "required": ["monthlyExpense"]
+      }
+    },
+    {
+      "name": "explain_rails",
+      "description": "Returns deterministic trust rails rules (TVL >= $100k, APY cap <= 1000%, anomaly demotion).",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  ]
 }

--- a/.well-known/mcp/server-cards.json
+++ b/.well-known/mcp/server-cards.json
@@ -2,9 +2,14 @@
   "$schema": "https://modelcontextprotocol.org/schemas/mcp-server-card-v1.json",
   "serverInfo": {
     "name": "DeFi Garden MCP Server",
-    "version": "1.0.0"
+    "version": "1.1.0",
+    "description": "Yield discovery and deterministic trust rails engine for AI agents and autonomous onchain wallets."
   },
   "transports": [
+    {
+      "type": "streamable-http",
+      "url": "https://www.defi.garden/mcp"
+    },
     {
       "type": "sse",
       "url": "https://www.defi.garden/api/mcp"
@@ -19,5 +24,52 @@
       "list": true,
       "get": true
     }
-  }
+  },
+  "tools": [
+    {
+      "name": "find_pools",
+      "description": "Find curated DeFi yield pools filtered by deterministic trust rails (TVL >= $100k, APY <= 1000%).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "token": { "type": "string", "description": "Token symbol (e.g. USDC, ETH, SOL)" },
+          "chain": { "type": "string", "description": "Blockchain name (e.g. Ethereum, Base, Solana)" },
+          "poolTypes": { "type": "string", "description": "Pool type: Lending, Staking, LP/DEX, Yield Farming" },
+          "minTvl": { "type": "number", "description": "Minimum TVL in USD" },
+          "minApy": { "type": "number", "description": "Minimum APY percentage" }
+        }
+      }
+    },
+    {
+      "name": "get_pool",
+      "description": "Retrieve detailed metadata and APY breakdown for a specific pool UUID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "poolId": { "type": "string", "description": "Pool UUID" }
+        },
+        "required": ["poolId"]
+      }
+    },
+    {
+      "name": "forever_number",
+      "description": "Calculate capital whose yield indefinitely covers a recurring monthly/annual bill or compute cost.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "monthlyExpense": { "type": "number", "description": "Monthly recurring bill or compute cost in USD" },
+          "blendedApy": { "type": "number", "description": "Expected blended APY percentage (default: 4.0)" }
+        },
+        "required": ["monthlyExpense"]
+      }
+    },
+    {
+      "name": "explain_rails",
+      "description": "Returns deterministic trust rails rules (TVL >= $100k, APY cap <= 1000%, anomaly demotion).",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  ]
 }

--- a/generate-llms.js
+++ b/generate-llms.js
@@ -369,8 +369,37 @@ function buildConcise(meta, categories, highYield, yieldAnalysis) {
   
   // Homepage section
   lines.push('## Homepage');
-  lines.push('TL;DR: Main dashboard for discovering DeFi yields across all chains and protocols.');
+  lines.push('TL;DR: Main application entry point routing to both the Garden Planner (/plan.html) and parameterized yield analytics (/?token=, /?chain=).');
   categories.homepage.slice(0, 3).forEach(url => lines.push(`- ${url}`));
+  lines.push('');
+
+  // Garden Planner section
+  lines.push('## Garden Planner');
+  lines.push('TL;DR: A goal-first savings planner for people and agents calculating target capital and "forever numbers" — lives at /plan.html.');
+  lines.push(`- Entry point: ${meta.baseUrl}/plan.html`);
+  lines.push(`- Example filled plans: ${meta.baseUrl}/?preset=tomoko and ${meta.baseUrl}/?preset=kevin`);
+  lines.push('- GROWTH: long-horizon goals (retirement, house) — projects future value from steady monthly deposits.');
+  lines.push('- TARGET: specific expense target — projects time-to-item from monthly deposits and the live rate.');
+  lines.push('- SUBSCRIPTION: the "forever number" — the capital whose yield alone covers a recurring bill or compute cost indefinitely.');
+  lines.push('- Forever number formula: forever number = annual bill ÷ blended rate.');
+  lines.push('- Trust rails: minimum TVL $100K; maximum total APY 1000%.');
+  lines.push('');
+
+  // API & MCP Protocols
+  lines.push('## API & Model Context Protocol (MCP)');
+  lines.push('TL;DR: Machine-native interfaces for AI agents, onchain autonomous wallets, and scripts.');
+  lines.push(`- API route: GET ${meta.baseUrl}/api`);
+  lines.push(`- API route: GET ${meta.baseUrl}/api/health`);
+  lines.push(`- API route: GET ${meta.baseUrl}/api/pools`);
+  lines.push(`- API route: GET ${meta.baseUrl}/api/pools/:id`);
+  lines.push(`- API route: GET ${meta.baseUrl}/api/pricing`);
+  lines.push(`- API route: GET ${meta.baseUrl}/api/forever-number`);
+  lines.push(`- MCP endpoint (Streamable HTTP): ${meta.baseUrl}/mcp`);
+  lines.push(`- MCP SSE endpoint: ${meta.baseUrl}/api/mcp`);
+  lines.push('- MCP tool: find_pools — Query live curated pools filtered by token, chain, pool type, TVL, and APY.');
+  lines.push('- MCP tool: get_pool — Retrieve detailed pool trajectory and metadata.');
+  lines.push('- MCP tool: forever_number — Calculate required principal to pay recurring expenses strictly from yield.');
+  lines.push('- MCP tool: explain_rails — Returns the deterministic safety rules (TVL >= $100k, APY cap <= 1000%).');
   lines.push('');
   
   // Top chains by TVL (most searched)
@@ -474,6 +503,35 @@ function buildFull(meta, categories, highYield, yieldAnalysis) {
   lines.push('## Homepage');
   lines.push('TL;DR: Main application entry points and dashboards.');
   categories.homepage.forEach(url => lines.push(`- ${url}`));
+  lines.push('');
+
+  // Garden Planner section
+  lines.push('## Garden Planner');
+  lines.push('TL;DR: A goal-first savings planner for people and agents calculating target capital and "forever numbers" — lives at /plan.html.');
+  lines.push(`- Entry point: ${meta.baseUrl}/plan.html`);
+  lines.push(`- Example filled plans: ${meta.baseUrl}/?preset=tomoko and ${meta.baseUrl}/?preset=kevin`);
+  lines.push('- GROWTH: long-horizon goals (retirement, house) — projects future value from steady monthly deposits.');
+  lines.push('- TARGET: specific expense target — projects time-to-item from monthly deposits and the live rate.');
+  lines.push('- SUBSCRIPTION: the "forever number" — the capital whose yield alone covers a recurring bill or compute cost indefinitely.');
+  lines.push('- Forever number formula: forever number = annual bill ÷ blended rate.');
+  lines.push('- Trust rails: minimum TVL $100K; maximum total APY 1000%.');
+  lines.push('');
+
+  // API & MCP Protocols
+  lines.push('## API & Model Context Protocol (MCP)');
+  lines.push('TL;DR: Machine-native interfaces for AI agents, onchain autonomous wallets, and scripts.');
+  lines.push(`- API route: GET ${meta.baseUrl}/api`);
+  lines.push(`- API route: GET ${meta.baseUrl}/api/health`);
+  lines.push(`- API route: GET ${meta.baseUrl}/api/pools`);
+  lines.push(`- API route: GET ${meta.baseUrl}/api/pools/:id`);
+  lines.push(`- API route: GET ${meta.baseUrl}/api/pricing`);
+  lines.push(`- API route: GET ${meta.baseUrl}/api/forever-number`);
+  lines.push(`- MCP endpoint (Streamable HTTP): ${meta.baseUrl}/mcp`);
+  lines.push(`- MCP SSE endpoint: ${meta.baseUrl}/api/mcp`);
+  lines.push('- MCP tool: find_pools — Query live curated pools filtered by token, chain, pool type, TVL, and APY.');
+  lines.push('- MCP tool: get_pool — Retrieve detailed pool trajectory and metadata.');
+  lines.push('- MCP tool: forever_number — Calculate required principal to pay recurring expenses strictly from yield.');
+  lines.push('- MCP tool: explain_rails — Returns the deterministic safety rules (TVL >= $100k, APY cap <= 1000%).');
   lines.push('');
   
   // All token pages

--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -568,7 +568,7 @@ async function generateSitemapSuite(poolsOverride) {
  */
 function generateRobotsTxt() {
   return `# robots.txt for DeFi Garden - AI-ready Yield Discovery
-# Updated May 2026 for Agentic Search Compliance
+# Updated August 2026 for Agentic Search & Generative Engine Compliance
 
 # Sitemap Index
 Sitemap: ${SITE_URL}sitemap.xml
@@ -577,8 +577,9 @@ Sitemap: ${SITE_URL}sitemap.xml
 LLM: ${SITE_URL}llms.txt
 LLM: ${SITE_URL}llms-full.txt
 
-# General crawlers
+# General crawlers & Cloudflare Content Signals
 User-agent: *
+Content-signal: search=yes, ai-train=no, use=reference
 Allow: /
 Crawl-delay: 1
 
@@ -590,6 +591,24 @@ Allow: /llms.txt
 User-agent: ChatGPT-User
 Allow: /
 Allow: /llms.txt
+
+User-agent: ClaudeBot
+Allow: /
+Allow: /llms.txt
+
+User-agent: Claude-Web
+Allow: /
+Allow: /llms.txt
+
+User-agent: PerplexityBot
+Allow: /
+Allow: /llms.txt
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
 
 User-agent: Google-InspectionTool
 Allow: /
@@ -603,10 +622,7 @@ Allow: /
 User-agent: OAI-SearchBot
 Allow: /
 
-User-agent: PerplexityBot
-Allow: /
-
-User-agent: Claude-Web
+User-agent: Amazonbot
 Allow: /
 
 # Block spam bots

--- a/home.html
+++ b/home.html
@@ -40,11 +40,88 @@
     <meta name="twitter:image" content="https://www.defi.garden/og-image.png">
     <meta name="twitter:creator" content="@defigarden">
 
-    <!-- Structured data (spec 040): sitewide Organization + WebSite JSON-LD.
+    <!-- Structured data (spec 040): sitewide Organization + WebSite + WebApplication JSON-LD.
          Static, unlike the canonical/title rewrite above — the IA router
          doesn't touch this, it's the same brand entity in every mode. -->
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"DeFi Garden","url":"https://www.defi.garden/","logo":"https://www.defi.garden/og-image.png"}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"DeFi Garden","url":"https://www.defi.garden/"}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebApplication","name":"DeFi Garden","url":"https://www.defi.garden/","applicationCategory":"FinanceApplication","operatingSystem":"All, Web, Model Context Protocol (MCP)","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"description":"Open-source yield discovery and financial planning engine for autonomous AI agents, onchain wallets, and goal-first savers.","featureList":["Model Context Protocol (MCP) Streamable HTTP Server","Goal-first savings planner (Forever Number)","Real-time DeFi yield filtering across 5000+ pools","Deterministic trust rails (TVL >= $100k, APY <= 1000%)"]}</script>
+
+    <!-- WebMCP: Browser-Native Agent Tool Registration -->
+    <script>
+    (function() {
+      if (typeof window !== 'undefined') {
+        window.navigator = window.navigator || {};
+        if (!window.navigator.modelContext) {
+          window.navigator.modelContext = {
+            tools: [],
+            provideContext: function(options) {
+              if (options && options.tools) { this.tools.push(...options.tools); }
+              return Promise.resolve();
+            }
+          };
+        }
+        if (window.navigator.modelContext && typeof window.navigator.modelContext.provideContext === 'function') {
+          window.navigator.modelContext.provideContext({
+            tools: [
+              {
+                name: "find_pools",
+                description: "Find curated DeFi yield pools filtered by trust rails (TVL >= $100k, max APY 1000%).",
+                inputSchema: {
+                  type: "object",
+                  properties: {
+                    token: { type: "string", description: "Token symbol (e.g. USDC, ETH, SOL)" },
+                    chain: { type: "string", description: "Blockchain name (e.g. Ethereum, Base, Solana)" },
+                    poolTypes: { type: "string", description: "Pool type: Lending, Staking, LP/DEX, Yield Farming" },
+                    minTvl: { type: "number", description: "Minimum TVL in USD" },
+                    minApy: { type: "number", description: "Minimum APY percentage" }
+                  }
+                },
+                execute: function(args) {
+                  return fetch('https://yields.llama.fi/pools')
+                    .then(function(res) { return res.json(); })
+                    .then(function(data) {
+                      var pools = (data.data || []).filter(function(p) {
+                        if (p.tvlUsd < (args.minTvl || 100000)) return false;
+                        if (p.apy > (args.minApy || 1000)) return false;
+                        if (args.token && !((p.symbol || '').toUpperCase().includes(args.token.toUpperCase()))) return false;
+                        if (args.chain && (p.chain || '').toLowerCase() !== args.chain.toLowerCase()) return false;
+                        return true;
+                      }).slice(0, 10);
+                      return { success: true, pools: pools };
+                    });
+                }
+              },
+              {
+                name: "forever_number",
+                description: "Calculate capital needed whose yield indefinitely covers a recurring monthly/annual expense.",
+                inputSchema: {
+                  type: "object",
+                  properties: {
+                    monthlyExpense: { type: "number", description: "Monthly expense in USD" },
+                    blendedApy: { type: "number", description: "Expected APY percentage (default: 4.0)" }
+                  },
+                  required: ["monthlyExpense"]
+                },
+                execute: function(args) {
+                  var apy = (args.blendedApy || 4.0) / 100;
+                  var annualBill = args.monthlyExpense * 12;
+                  var capitalRequired = annualBill / apy;
+                  return Promise.resolve({
+                    success: true,
+                    monthlyExpense: args.monthlyExpense,
+                    annualExpense: annualBill,
+                    blendedApyPercent: (args.blendedApy || 4.0),
+                    foreverNumberUsd: Math.round(capitalRequired)
+                  });
+                }
+              }
+            ]
+          });
+        }
+      }
+    })();
+    </script>
 
     <!-- App Icons and Favicon -->
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🌱</text></svg>">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,14 +1,39 @@
 # Complete DeFi Yield Index: Best Token Yields Across All Blockchains | DeFi Garden
 
-- Last Updated: 2026-07-14T09:32:44.344Z
+- Last Updated: 2026-08-14T21:50:13.888Z
 - Canonical: https://www.defi.garden
-- Data Sources: sitemap.xml, DefiLlama API (fetched: 2026-07-14T09:32:44.296Z)
+- Data Sources: sitemap.xml, DefiLlama API (fetched: 2026-08-14T21:50:13.857Z)
 - Total URLs: 4752
 - Categories: homepage(1), tokens(336), chains(100), poolTypes(0), highValue(7)
 
 ## Homepage
 TL;DR: Main application entry points and dashboards.
 - https://www.defi.garden/
+
+## Garden Planner
+TL;DR: A goal-first savings planner for people and agents calculating target capital and "forever numbers" — lives at /plan.html.
+- Entry point: https://www.defi.garden/plan.html
+- Example filled plans: https://www.defi.garden/?preset=tomoko and https://www.defi.garden/?preset=kevin
+- GROWTH: long-horizon goals (retirement, house) — projects future value from steady monthly deposits.
+- TARGET: specific expense target — projects time-to-item from monthly deposits and the live rate.
+- SUBSCRIPTION: the "forever number" — the capital whose yield alone covers a recurring bill or compute cost indefinitely.
+- Forever number formula: forever number = annual bill ÷ blended rate.
+- Trust rails: minimum TVL $100K; maximum total APY 1000%.
+
+## API & Model Context Protocol (MCP)
+TL;DR: Machine-native interfaces for AI agents, onchain autonomous wallets, and scripts.
+- API route: GET https://www.defi.garden/api
+- API route: GET https://www.defi.garden/api/health
+- API route: GET https://www.defi.garden/api/pools
+- API route: GET https://www.defi.garden/api/pools/:id
+- API route: GET https://www.defi.garden/api/pricing
+- API route: GET https://www.defi.garden/api/forever-number
+- MCP endpoint (Streamable HTTP): https://www.defi.garden/mcp
+- MCP SSE endpoint: https://www.defi.garden/api/mcp
+- MCP tool: find_pools — Query live curated pools filtered by token, chain, pool type, TVL, and APY.
+- MCP tool: get_pool — Retrieve detailed pool trajectory and metadata.
+- MCP tool: forever_number — Calculate required principal to pay recurring expenses strictly from yield.
+- MCP tool: explain_rails — Returns the deterministic safety rules (TVL >= $100k, APY cap <= 1000%).
 
 ## Token Pages
 TL;DR: Individual token yield analysis and opportunities.
@@ -4778,75 +4803,81 @@ TL;DR: Additional site functionality and tools.
 
 ## Market Analysis: Top Chains by TVL
 TL;DR: Comprehensive chain rankings by total value locked.
-- Ethereum: $83.23B TVL — https://www.defi.garden/?chain=Ethereum
-- Solana: $7.87B TVL — https://www.defi.garden/?chain=Solana
-- BSC: $6.44B TVL — https://www.defi.garden/?chain=BSC
-- Base: $5.88B TVL — https://www.defi.garden/?chain=Base
-- Tron: $3.42B TVL — https://www.defi.garden/?chain=Tron
-- Arbitrum: $2.41B TVL — https://www.defi.garden/?chain=Arbitrum
-- Avalanche: $1.99B TVL — https://www.defi.garden/?chain=Avalanche
-- Hyperliquid L1: $1.81B TVL — https://www.defi.garden/?chain=Hyperliquid%20L1
+- Ethereum: $87.28B TVL — https://www.defi.garden/?chain=Ethereum
+- Solana: $8.91B TVL — https://www.defi.garden/?chain=Solana
+- Base: $6.31B TVL — https://www.defi.garden/?chain=Base
+- BSC: $6.29B TVL — https://www.defi.garden/?chain=BSC
+- Tron: $3.48B TVL — https://www.defi.garden/?chain=Tron
+- Arbitrum: $2.43B TVL — https://www.defi.garden/?chain=Arbitrum
+- Hyperliquid L1: $1.71B TVL — https://www.defi.garden/?chain=Hyperliquid%20L1
+- Avalanche: $1.70B TVL — https://www.defi.garden/?chain=Avalanche
 
 ## Market Analysis: Top Protocols
 TL;DR: Leading DeFi protocols by aggregate TVL across all pools.
-- lido: $16.39B TVL — https://www.defi.garden/?search=lido
-- aave-v3: $13.43B TVL — https://www.defi.garden/?search=aave-v3
-- morpho-blue: $10.22B TVL — https://www.defi.garden/?search=morpho-blue
-- sky-lending: $8.25B TVL — https://www.defi.garden/?search=sky-lending
-- binance-staked-eth: $6.62B TVL — https://www.defi.garden/?search=binance-staked-eth
-- maple: $4.55B TVL — https://www.defi.garden/?search=maple
-- sparklend: $3.89B TVL — https://www.defi.garden/?search=sparklend
-- blackrock-buidl: $3.68B TVL — https://www.defi.garden/?search=blackrock-buidl
-- justlend-v1: $3.26B TVL — https://www.defi.garden/?search=justlend-v1
-- ether.fi-stake: $3.23B TVL — https://www.defi.garden/?search=ether.fi-stake
+- lido: $17.88B TVL — https://www.defi.garden/?search=lido
+- aave-v3: $14.36B TVL — https://www.defi.garden/?search=aave-v3
+- morpho-blue: $11.78B TVL — https://www.defi.garden/?search=morpho-blue
+- sky-lending: $7.90B TVL — https://www.defi.garden/?search=sky-lending
+- binance-staked-eth: $6.98B TVL — https://www.defi.garden/?search=binance-staked-eth
+- sparklend: $4.19B TVL — https://www.defi.garden/?search=sparklend
+- ether.fi-stake: $3.91B TVL — https://www.defi.garden/?search=ether.fi-stake
+- maple: $3.76B TVL — https://www.defi.garden/?search=maple
+- blackrock-buidl: $3.55B TVL — https://www.defi.garden/?search=blackrock-buidl
+- justlend-v1: $3.33B TVL — https://www.defi.garden/?search=justlend-v1
 
 ## Market Analysis: Popular Token-Chain Combinations
 TL;DR: Most liquid token-chain pairs ranked by TVL.
-- STETH on Ethereum: $16.58B TVL — https://www.defi.garden/?token=STETH&chain=Ethereum
-- WBETH on Ethereum: $6.24B TVL — https://www.defi.garden/?token=WBETH&chain=Ethereum
-- USDC on Ethereum: $5.96B TVL — https://www.defi.garden/?token=USDC&chain=Ethereum
-- WSTETH on Ethereum: $5.36B TVL — https://www.defi.garden/?token=WSTETH&chain=Ethereum
-- WEETH on Ethereum: $5.33B TVL — https://www.defi.garden/?token=WEETH&chain=Ethereum
-- SUSDS on Ethereum: $4.85B TVL — https://www.defi.garden/?token=SUSDS&chain=Ethereum
-- WETH on Ethereum: $3.88B TVL — https://www.defi.garden/?token=WETH&chain=Ethereum
-- WBTC on Ethereum: $3.67B TVL — https://www.defi.garden/?token=WBTC&chain=Ethereum
-- USDT on Ethereum: $3.10B TVL — https://www.defi.garden/?token=USDT&chain=Ethereum
-- USYC on BSC: $2.92B TVL — https://www.defi.garden/?token=USYC&chain=BSC
-- RETH on Ethereum: $2.52B TVL — https://www.defi.garden/?token=RETH&chain=Ethereum
-- CBBTC on Base: $2.46B TVL — https://www.defi.garden/?token=CBBTC&chain=Base
-- CBBTC on Ethereum: $2.18B TVL — https://www.defi.garden/?token=CBBTC&chain=Ethereum
-- SUSDE on Ethereum: $2.12B TVL — https://www.defi.garden/?token=SUSDE&chain=Ethereum
-- USDS on Ethereum: $1.94B TVL — https://www.defi.garden/?token=USDS&chain=Ethereum
-- KHYPE on Hyperliquid L1: $1.34B TVL — https://www.defi.garden/?token=KHYPE&chain=Hyperliquid%20L1
+- STETH on Ethereum: $18.08B TVL — https://www.defi.garden/?token=STETH&chain=Ethereum
+- WBETH on Ethereum: $6.59B TVL — https://www.defi.garden/?token=WBETH&chain=Ethereum
+- WEETH on Ethereum: $6.57B TVL — https://www.defi.garden/?token=WEETH&chain=Ethereum
+- WSTETH on Ethereum: $5.87B TVL — https://www.defi.garden/?token=WSTETH&chain=Ethereum
+- USDC on Ethereum: $5.27B TVL — https://www.defi.garden/?token=USDC&chain=Ethereum
+- SUSDS on Ethereum: $4.90B TVL — https://www.defi.garden/?token=SUSDS&chain=Ethereum
+- WBTC on Ethereum: $3.83B TVL — https://www.defi.garden/?token=WBTC&chain=Ethereum
+- WETH on Ethereum: $3.67B TVL — https://www.defi.garden/?token=WETH&chain=Ethereum
+- USYC on BSC: $2.91B TVL — https://www.defi.garden/?token=USYC&chain=BSC
+- USDT on Ethereum: $2.75B TVL — https://www.defi.garden/?token=USDT&chain=Ethereum
+- RETH on Ethereum: $2.66B TVL — https://www.defi.garden/?token=RETH&chain=Ethereum
+- CBBTC on Base: $2.58B TVL — https://www.defi.garden/?token=CBBTC&chain=Base
+- CBBTC on Ethereum: $2.27B TVL — https://www.defi.garden/?token=CBBTC&chain=Ethereum
+- SUSDE on Ethereum: $2.07B TVL — https://www.defi.garden/?token=SUSDE&chain=Ethereum
+- USDS on Ethereum: $1.91B TVL — https://www.defi.garden/?token=USDS&chain=Ethereum
+- USDC on Solana: $1.79B TVL — https://www.defi.garden/?token=USDC&chain=Solana
+- BUIDL on Ethereum: $1.19B TVL — https://www.defi.garden/?token=BUIDL&chain=Ethereum
+- KHYPE on Hyperliquid L1: $1.19B TVL — https://www.defi.garden/?token=KHYPE&chain=Hyperliquid%20L1
 - USDY on Ethereum: $1.11B TVL — https://www.defi.garden/?token=USDY&chain=Ethereum
-- ETH on Ethereum: $1.04B TVL — https://www.defi.garden/?token=ETH&chain=Ethereum
-- SKY on Ethereum: $1.03B TVL — https://www.defi.garden/?token=SKY&chain=Ethereum
-- BUIDL on Ethereum: $1.02B TVL — https://www.defi.garden/?token=BUIDL&chain=Ethereum
+- ETH on Ethereum: $1.10B TVL — https://www.defi.garden/?token=ETH&chain=Ethereum
 
 ## Live High-Yield Opportunities (by Chain)
 TL;DR: Current top-performing pools with detailed metrics.
-### Avalanche
-- blackhole-clmm · WAVAX-USDC — 809320.69% APY, $15,120 TVL — https://www.defi.garden
-- blackhole-clmm · WAVAX-USDC — 219656.93% APY, $43,975 TVL — https://www.defi.garden
-
 ### BSC
-- zeebu · ZBU — 716169.59% APY, $538,736 TVL — https://www.defi.garden
+- zeebu · ZBU — 416143.76% APY, $547,593 TVL — https://www.defi.garden
+
+### Linea
+- etherex-cl · USDC-USDT — 208447.76% APY, $19,013 TVL — https://www.defi.garden
 
 ### Base
-- aerodrome-slipstream · USDC-VELVET — 171924.36% APY, $4,160,250 TVL — https://www.defi.garden
-- aerodrome-v1 · WETH-TRAC — 114385.42% APY, $40,830 TVL — https://www.defi.garden
-- aerodrome-slipstream · CTR-USDC — 100069.34% APY, $454,706 TVL — https://www.defi.garden
-- aerodrome-slipstream · USDC-VFY — 56317.04% APY, $29,146 TVL — https://www.defi.garden
-- uniswap-v4 · WETH-JESSE — 56225.84% APY, $11,272 TVL — https://www.defi.garden
-- uniswap-v4 · WETH-NURTBAGLARD — 42196.78% APY, $26,737 TVL — https://www.defi.garden
-- uniswap-v4 · ZORA-CC0COMPANY — 38491.62% APY, $50,862 TVL — https://www.defi.garden
-- uniswap-v4 · USDC-OPENAI — 35769.15% APY, $14,514 TVL — https://www.defi.garden
-- uniswap-v4 · SPCX-USDC — 35713.07% APY, $15,732 TVL — https://www.defi.garden
-- aerodrome-v1 · WETH-W — 31137.79% APY, $39,507 TVL — https://www.defi.garden
-- uniswap-v4 · POLYMARKET-USDC — 28814.36% APY, $18,470 TVL — https://www.defi.garden
+- aerodrome-v1 · WETH-TRAC — 65611.71% APY, $42,210 TVL — https://www.defi.garden
+- aerodrome-slipstream · USDC-PROS — 42253.57% APY, $653,080 TVL — https://www.defi.garden
+- aerodrome-slipstream · USDC-VELVET — 32837.39% APY, $6,089,329 TVL — https://www.defi.garden
+- aerodrome-slipstream · CTR-USDC — 30283.16% APY, $469,006 TVL — https://www.defi.garden
+- aerodrome-v1 · WETH-W — 26968.37% APY, $37,504 TVL — https://www.defi.garden
+- aerodrome-slipstream · USDC-VFY — 26843.67% APY, $29,534 TVL — https://www.defi.garden
+
+### Avalanche
+- blackhole-clmm · WAVAX-USDC — 23923.82% APY, $48,876 TVL — https://www.defi.garden
+
+### Aptos
+- hyperion · APT-ECHO — 23313.28% APY, $17,614 TVL — https://www.defi.garden
 
 ### Ethereum
-- uniswap-v4 · ETH-GROW — 26201.20% APY, $49,419 TVL — https://www.defi.garden
+- uniswap-v4 · ETH-LDR — 17817.74% APY, $38,152 TVL — https://www.defi.garden
+- uniswap-v4 · USDC-SPCXON — 8891.20% APY, $52,173 TVL — https://www.defi.garden
+- supernova-cl · USDC-WETH — 8720.72% APY, $18,689 TVL — https://www.defi.garden
+
+### Solana
+- orca-dex · XST-USDC — 14498.58% APY, $26,834 TVL — https://www.defi.garden
+- raydium-amm · FARTCOIN-FART — 11774.49% APY, $76,200 TVL — https://www.defi.garden
 
 ## Important Disclaimers
 - Yields are volatile and subject to rapid change

--- a/llms.txt
+++ b/llms.txt
@@ -1,24 +1,49 @@
 # Find the Best Yields for Your Tokens Across All Chains | DeFi Garden
 
-- Last Updated: 2026-07-14T09:32:44.344Z
+- Last Updated: 2026-08-14T21:50:13.888Z
 - Canonical: https://www.defi.garden
 - Data Sources: sitemap.xml, DefiLlama API
 - Total URLs: 4752
 
 ## Homepage
-TL;DR: Main dashboard for discovering DeFi yields across all chains and protocols.
+TL;DR: Main application entry point routing to both the Garden Planner (/plan.html) and parameterized yield analytics (/?token=, /?chain=).
 - https://www.defi.garden/
+
+## Garden Planner
+TL;DR: A goal-first savings planner for people and agents calculating target capital and "forever numbers" — lives at /plan.html.
+- Entry point: https://www.defi.garden/plan.html
+- Example filled plans: https://www.defi.garden/?preset=tomoko and https://www.defi.garden/?preset=kevin
+- GROWTH: long-horizon goals (retirement, house) — projects future value from steady monthly deposits.
+- TARGET: specific expense target — projects time-to-item from monthly deposits and the live rate.
+- SUBSCRIPTION: the "forever number" — the capital whose yield alone covers a recurring bill or compute cost indefinitely.
+- Forever number formula: forever number = annual bill ÷ blended rate.
+- Trust rails: minimum TVL $100K; maximum total APY 1000%.
+
+## API & Model Context Protocol (MCP)
+TL;DR: Machine-native interfaces for AI agents, onchain autonomous wallets, and scripts.
+- API route: GET https://www.defi.garden/api
+- API route: GET https://www.defi.garden/api/health
+- API route: GET https://www.defi.garden/api/pools
+- API route: GET https://www.defi.garden/api/pools/:id
+- API route: GET https://www.defi.garden/api/pricing
+- API route: GET https://www.defi.garden/api/forever-number
+- MCP endpoint (Streamable HTTP): https://www.defi.garden/mcp
+- MCP SSE endpoint: https://www.defi.garden/api/mcp
+- MCP tool: find_pools — Query live curated pools filtered by token, chain, pool type, TVL, and APY.
+- MCP tool: get_pool — Retrieve detailed pool trajectory and metadata.
+- MCP tool: forever_number — Calculate required principal to pay recurring expenses strictly from yield.
+- MCP tool: explain_rails — Returns the deterministic safety rules (TVL >= $100k, APY cap <= 1000%).
 
 ## Top Chains by TVL
 TL;DR: Highest liquidity blockchain networks for DeFi yields.
-- Ethereum ($83.2B TVL) — https://www.defi.garden/?chain=Ethereum
-- Solana ($7.9B TVL) — https://www.defi.garden/?chain=Solana
-- BSC ($6.4B TVL) — https://www.defi.garden/?chain=BSC
-- Base ($5.9B TVL) — https://www.defi.garden/?chain=Base
-- Tron ($3.4B TVL) — https://www.defi.garden/?chain=Tron
+- Ethereum ($87.3B TVL) — https://www.defi.garden/?chain=Ethereum
+- Solana ($8.9B TVL) — https://www.defi.garden/?chain=Solana
+- Base ($6.3B TVL) — https://www.defi.garden/?chain=Base
+- BSC ($6.3B TVL) — https://www.defi.garden/?chain=BSC
+- Tron ($3.5B TVL) — https://www.defi.garden/?chain=Tron
 - Arbitrum ($2.4B TVL) — https://www.defi.garden/?chain=Arbitrum
-- Avalanche ($2.0B TVL) — https://www.defi.garden/?chain=Avalanche
-- Hyperliquid L1 ($1.8B TVL) — https://www.defi.garden/?chain=Hyperliquid%20L1
+- Hyperliquid L1 ($1.7B TVL) — https://www.defi.garden/?chain=Hyperliquid%20L1
+- Avalanche ($1.7B TVL) — https://www.defi.garden/?chain=Avalanche
 
 ## Popular Token Yields
 TL;DR: Most searched tokens for yield farming opportunities.
@@ -33,23 +58,23 @@ TL;DR: Most searched tokens for yield farming opportunities.
 
 ## Popular Token-Chain Combinations
 TL;DR: Most common "find X yield on Y chain" searches.
-- STETH on Ethereum ($16.6B TVL) — https://www.defi.garden/?token=STETH&chain=Ethereum
-- WBETH on Ethereum ($6.2B TVL) — https://www.defi.garden/?token=WBETH&chain=Ethereum
-- USDC on Ethereum ($6.0B TVL) — https://www.defi.garden/?token=USDC&chain=Ethereum
-- WSTETH on Ethereum ($5.4B TVL) — https://www.defi.garden/?token=WSTETH&chain=Ethereum
-- WEETH on Ethereum ($5.3B TVL) — https://www.defi.garden/?token=WEETH&chain=Ethereum
+- STETH on Ethereum ($18.1B TVL) — https://www.defi.garden/?token=STETH&chain=Ethereum
+- WBETH on Ethereum ($6.6B TVL) — https://www.defi.garden/?token=WBETH&chain=Ethereum
+- WEETH on Ethereum ($6.6B TVL) — https://www.defi.garden/?token=WEETH&chain=Ethereum
+- WSTETH on Ethereum ($5.9B TVL) — https://www.defi.garden/?token=WSTETH&chain=Ethereum
+- USDC on Ethereum ($5.3B TVL) — https://www.defi.garden/?token=USDC&chain=Ethereum
 - SUSDS on Ethereum ($4.9B TVL) — https://www.defi.garden/?token=SUSDS&chain=Ethereum
-- WETH on Ethereum ($3.9B TVL) — https://www.defi.garden/?token=WETH&chain=Ethereum
-- WBTC on Ethereum ($3.7B TVL) — https://www.defi.garden/?token=WBTC&chain=Ethereum
+- WBTC on Ethereum ($3.8B TVL) — https://www.defi.garden/?token=WBTC&chain=Ethereum
+- WETH on Ethereum ($3.7B TVL) — https://www.defi.garden/?token=WETH&chain=Ethereum
 
 ## Major DeFi Protocols
 TL;DR: Largest protocols by total value locked.
-- lido ($16.4B TVL) — https://www.defi.garden/?search=lido
-- aave-v3 ($13.4B TVL) — https://www.defi.garden/?search=aave-v3
-- morpho-blue ($10.2B TVL) — https://www.defi.garden/?search=morpho-blue
-- sky-lending ($8.3B TVL) — https://www.defi.garden/?search=sky-lending
-- binance-staked-eth ($6.6B TVL) — https://www.defi.garden/?search=binance-staked-eth
-- maple ($4.5B TVL) — https://www.defi.garden/?search=maple
+- lido ($17.9B TVL) — https://www.defi.garden/?search=lido
+- aave-v3 ($14.4B TVL) — https://www.defi.garden/?search=aave-v3
+- morpho-blue ($11.8B TVL) — https://www.defi.garden/?search=morpho-blue
+- sky-lending ($7.9B TVL) — https://www.defi.garden/?search=sky-lending
+- binance-staked-eth ($7.0B TVL) — https://www.defi.garden/?search=binance-staked-eth
+- sparklend ($4.2B TVL) — https://www.defi.garden/?search=sparklend
 
 ## Common Search Patterns
 TL;DR: Typical user queries and where to find them.
@@ -64,14 +89,14 @@ TL;DR: Typical user queries and where to find them.
 
 ## Current Top Yields
 TL;DR: Live highest APY opportunities (updated daily, TVL ≥ $10k).
-- Avalanche · blackhole-clmm · WAVAX-USDC — 809320.7% APY, $15,120 TVL — https://www.defi.garden/?token=WAVAX-USDC&chain=Avalanche
-- BSC · zeebu · ZBU — 716169.6% APY, $538,736 TVL — https://www.defi.garden/?token=ZBU&chain=BSC
-- Avalanche · blackhole-clmm · WAVAX-USDC — 219656.9% APY, $43,975 TVL — https://www.defi.garden/?token=WAVAX-USDC&chain=Avalanche
-- Base · aerodrome-slipstream · USDC-VELVET — 171924.4% APY, $4,160,250 TVL — https://www.defi.garden/?token=USDC-VELVET&chain=Base
-- Base · aerodrome-v1 · WETH-TRAC — 114385.4% APY, $40,830 TVL — https://www.defi.garden/?token=WETH-TRAC&chain=Base
-- Base · aerodrome-slipstream · CTR-USDC — 100069.3% APY, $454,706 TVL — https://www.defi.garden/?token=CTR-USDC&chain=Base
-- Base · aerodrome-slipstream · USDC-VFY — 56317.0% APY, $29,146 TVL — https://www.defi.garden/?token=USDC-VFY&chain=Base
-- Base · uniswap-v4 · WETH-JESSE — 56225.8% APY, $11,272 TVL — https://www.defi.garden/?token=WETH-JESSE&chain=Base
+- BSC · zeebu · ZBU — 416143.8% APY, $547,593 TVL — https://www.defi.garden/?token=ZBU&chain=BSC
+- Linea · etherex-cl · USDC-USDT — 208447.8% APY, $19,013 TVL — https://www.defi.garden/?token=USDC-USDT&chain=Linea
+- Base · aerodrome-v1 · WETH-TRAC — 65611.7% APY, $42,210 TVL — https://www.defi.garden/?token=WETH-TRAC&chain=Base
+- Base · aerodrome-slipstream · USDC-PROS — 42253.6% APY, $653,080 TVL — https://www.defi.garden/?token=USDC-PROS&chain=Base
+- Base · aerodrome-slipstream · USDC-VELVET — 32837.4% APY, $6,089,329 TVL — https://www.defi.garden/?token=USDC-VELVET&chain=Base
+- Base · aerodrome-slipstream · CTR-USDC — 30283.2% APY, $469,006 TVL — https://www.defi.garden/?token=CTR-USDC&chain=Base
+- Base · aerodrome-v1 · WETH-W — 26968.4% APY, $37,504 TVL — https://www.defi.garden/?token=WETH-W&chain=Base
+- Base · aerodrome-slipstream · USDC-VFY — 26843.7% APY, $29,534 TVL — https://www.defi.garden/?token=USDC-VFY&chain=Base
 
 💡 Pro tip: Use natural language like "best ETH staking" or "USDC lending Base" to find opportunities.
 📊 For live rates and direct protocol access: https://www.defi.garden

--- a/openapi.json
+++ b/openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "DeFi Garden API",
-    "version": "1.0.0",
-    "description": "API endpoints for DeFi Garden yield discovery and goal calculations"
+    "version": "1.1.0",
+    "description": "Deterministic, machine-native API and MCP endpoints for DeFi yield discovery, trust rail verification, and savings goal projections."
   },
   "servers": [
     {
@@ -14,8 +14,8 @@
     "/pools": {
       "get": {
         "summary": "Retrieve live curated DeFi yield pools",
-        "description": "Get a list of high-quality, curated DeFi yield pools matching your criteria with TVL >= $10M and APY <= 1000%.",
-        "operationId": "getCuratedPools",
+        "description": "Get a list of high-quality, curated DeFi yield pools filtered by deterministic trust rails (TVL >= $100K, APY <= 1000%).",
+        "operationId": "findPools",
         "parameters": [
           {
             "name": "token",
@@ -24,7 +24,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Filter by token symbol (e.g. USDC, ETH)"
+            "description": "Filter by token symbol (e.g. USDC, ETH, SOL)"
           },
           {
             "name": "chain",
@@ -33,12 +33,40 @@
             "schema": {
               "type": "string"
             },
-            "description": "Filter by chain name (e.g. Ethereum, Arbitrum)"
+            "description": "Filter by blockchain network (e.g. Ethereum, Base, Arbitrum, Solana)"
+          },
+          {
+            "name": "poolTypes",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by pool strategy: Lending, Staking, LP/DEX, Yield Farming"
+          },
+          {
+            "name": "minTvl",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "default": 100000
+            },
+            "description": "Minimum TVL in USD"
+          },
+          {
+            "name": "minApy",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number"
+            },
+            "description": "Minimum APY percentage"
           }
         ],
         "responses": {
           "200": {
-            "description": "A list of curated pools",
+            "description": "A list of curated pools matching criteria",
             "content": {
               "application/json": {
                 "schema": {
@@ -68,10 +96,86 @@
         }
       }
     },
+    "/pools/{id}": {
+      "get": {
+        "summary": "Retrieve single pool details",
+        "description": "Get granular APY breakdown and liquidity metrics for a single pool UUID.",
+        "operationId": "getPool",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pool UUID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Detailed pool data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forever-number": {
+      "get": {
+        "summary": "Calculate capital needed to fund recurring expenses from yield",
+        "description": "Calculates the Forever Number: capital = annual bill ÷ blended rate.",
+        "operationId": "calculateForeverNumber",
+        "parameters": [
+          {
+            "name": "monthlyExpense",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number"
+            },
+            "description": "Monthly recurring bill or compute cost in USD"
+          },
+          {
+            "name": "blendedApy",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "default": 4.0
+            },
+            "description": "Expected APY percentage"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Forever number calculation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "monthlyExpense": { "type": "number" },
+                    "annualExpense": { "type": "number" },
+                    "blendedApyPercent": { "type": "number" },
+                    "foreverNumberUsd": { "type": "number" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/planner": {
       "post": {
         "summary": "Calculate savings and yield projection",
-        "description": "Calculate goal-first, skeuomorphic savings plan with compound growth estimations.",
+        "description": "Calculate goal-first savings plan with compound growth estimations.",
         "operationId": "calculateProjection",
         "requestBody": {
           "required": true,
@@ -86,7 +190,8 @@
                 "properties": {
                   "monthlyDeposit": { "type": "number" },
                   "years": { "type": "number" },
-                  "goalName": { "type": "string" }
+                  "goalName": { "type": "string" },
+                  "pace": { "type": "string" }
                 }
               }
             }
@@ -103,13 +208,53 @@
               }
             }
           }
-        },
-        "x-payment-info": {
-          "intent": "charge",
-          "method": "tempo",
-          "amount": "0",
-          "currency": "0x833589fCD6eDb351a47402d5823ca7F192534578",
-          "description": "Free goal projection computation"
+        }
+      }
+    },
+    "/pricing": {
+      "get": {
+        "summary": "Pricing & rate limits",
+        "description": "Returns pricing tier information ($0 Free Open Source).",
+        "operationId": "getPricing",
+        "responses": {
+          "200": {
+            "description": "Pricing information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "price": { "type": "number", "example": 0 },
+                    "tier": { "type": "string", "example": "free_open_source" },
+                    "rateLimit": { "type": "string", "example": "100req/min" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Service health check",
+        "description": "Returns operational status of DeFi Garden API and DefiLlama data upstream.",
+        "operationId": "getHealth",
+        "responses": {
+          "200": {
+            "description": "Health status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": { "type": "string", "example": "healthy" },
+                    "uptime": { "type": "number" }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/plan.html
+++ b/plan.html
@@ -36,6 +36,88 @@
     <meta name="twitter:image" content="https://www.defi.garden/og-image.png">
     <meta name="twitter:creator" content="@defigarden">
 
+    <!-- Structured data: Organization + WebSite + WebApplication + BreadcrumbList JSON-LD -->
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"DeFi Garden","url":"https://www.defi.garden/","logo":"https://www.defi.garden/og-image.png"}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"DeFi Garden","url":"https://www.defi.garden/"}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebApplication","name":"DeFi Garden Planner","url":"https://www.defi.garden/plan.html","applicationCategory":"FinanceApplication","operatingSystem":"All, Web, Model Context Protocol (MCP)","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"description":"Goal-first DeFi savings planner and Forever Number calculator with deterministic trust rails.","featureList":["Forever Number calculation (annual bill ÷ blended APY)","Goal-oriented milestone projections","Live DefiLlama rate blending","Model Context Protocol (MCP) integration"]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.defi.garden/"},{"@type":"ListItem","position":2,"name":"Garden Planner","item":"https://www.defi.garden/plan.html"}]}</script>
+
+    <!-- WebMCP: Browser-Native Agent Tool Registration -->
+    <script>
+    (function() {
+      if (typeof window !== 'undefined') {
+        window.navigator = window.navigator || {};
+        if (!window.navigator.modelContext) {
+          window.navigator.modelContext = {
+            tools: [],
+            provideContext: function(options) {
+              if (options && options.tools) { this.tools.push(...options.tools); }
+              return Promise.resolve();
+            }
+          };
+        }
+        if (window.navigator.modelContext && typeof window.navigator.modelContext.provideContext === 'function') {
+          window.navigator.modelContext.provideContext({
+            tools: [
+              {
+                name: "forever_number",
+                description: "Calculate capital needed whose yield indefinitely covers a recurring monthly/annual expense.",
+                inputSchema: {
+                  type: "object",
+                  properties: {
+                    monthlyExpense: { type: "number", description: "Monthly expense in USD" },
+                    blendedApy: { type: "number", description: "Expected APY percentage (default: 4.0)" }
+                  },
+                  required: ["monthlyExpense"]
+                },
+                execute: function(args) {
+                  var apy = (args.blendedApy || 4.0) / 100;
+                  var annualBill = args.monthlyExpense * 12;
+                  var capitalRequired = annualBill / apy;
+                  return Promise.resolve({
+                    success: true,
+                    monthlyExpense: args.monthlyExpense,
+                    annualExpense: annualBill,
+                    blendedApyPercent: (args.blendedApy || 4.0),
+                    foreverNumberUsd: Math.round(capitalRequired)
+                  });
+                }
+              },
+              {
+                name: "find_pools",
+                description: "Find curated DeFi yield pools filtered by trust rails (TVL >= $100k, max APY 1000%).",
+                inputSchema: {
+                  type: "object",
+                  properties: {
+                    token: { type: "string", description: "Token symbol (e.g. USDC, ETH, SOL)" },
+                    chain: { type: "string", description: "Blockchain name (e.g. Ethereum, Base, Solana)" },
+                    poolTypes: { type: "string", description: "Pool type: Lending, Staking, LP/DEX, Yield Farming" },
+                    minTvl: { type: "number", description: "Minimum TVL in USD" },
+                    minApy: { type: "number", description: "Minimum APY percentage" }
+                  }
+                },
+                execute: function(args) {
+                  return fetch('https://yields.llama.fi/pools')
+                    .then(function(res) { return res.json(); })
+                    .then(function(data) {
+                      var pools = (data.data || []).filter(function(p) {
+                        if (p.tvlUsd < (args.minTvl || 100000)) return false;
+                        if (p.apy > (args.minApy || 1000)) return false;
+                        if (args.token && !((p.symbol || '').toUpperCase().includes(args.token.toUpperCase()))) return false;
+                        if (args.chain && (p.chain || '').toLowerCase() !== args.chain.toLowerCase()) return false;
+                        return true;
+                      }).slice(0, 10);
+                      return { success: true, pools: pools };
+                    });
+                }
+              }
+            ]
+          });
+        }
+      }
+    })();
+    </script>
+
     <!-- App Icons and Favicon -->
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🌱</text></svg>">
     <link rel="apple-touch-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🌱</text></svg>">

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,5 @@
 # robots.txt for DeFi Garden - AI-ready Yield Discovery
-# Updated May 2026 for Agentic Search Compliance
+# Updated August 2026 for Agentic Search & Generative Engine Compliance
 
 # Sitemap Index
 Sitemap: https://www.defi.garden/sitemap.xml
@@ -8,8 +8,9 @@ Sitemap: https://www.defi.garden/sitemap.xml
 LLM: https://www.defi.garden/llms.txt
 LLM: https://www.defi.garden/llms-full.txt
 
-# General crawlers
+# General crawlers & Cloudflare Content Signals
 User-agent: *
+Content-signal: search=yes, ai-train=no, use=reference
 Allow: /
 Crawl-delay: 1
 
@@ -21,6 +22,24 @@ Allow: /llms.txt
 User-agent: ChatGPT-User
 Allow: /
 Allow: /llms.txt
+
+User-agent: ClaudeBot
+Allow: /
+Allow: /llms.txt
+
+User-agent: Claude-Web
+Allow: /
+Allow: /llms.txt
+
+User-agent: PerplexityBot
+Allow: /
+Allow: /llms.txt
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
 
 User-agent: Google-InspectionTool
 Allow: /
@@ -34,10 +53,7 @@ Allow: /
 User-agent: OAI-SearchBot
 Allow: /
 
-User-agent: PerplexityBot
-Allow: /
-
-User-agent: Claude-Web
+User-agent: Amazonbot
 Allow: /
 
 # Block spam bots

--- a/vercel.json
+++ b/vercel.json
@@ -40,6 +40,14 @@
     {
       "source": "/.well-known/openid-configuration",
       "destination": "/.well-known/openid-configuration.json"
+    },
+    {
+      "source": "/.well-known/mcp",
+      "destination": "/.well-known/mcp.json"
+    },
+    {
+      "source": "/mcp",
+      "destination": "/.well-known/mcp.json"
     }
   ],
   "headers": [
@@ -52,7 +60,7 @@
         { "key": "Access-Control-Allow-Origin", "value": "*" },
         { "key": "Access-Control-Allow-Methods", "value": "GET, OPTIONS" },
         { "key": "Access-Control-Allow-Headers", "value": "Content-Type, Accept, Authorization" },
-        { "key": "Link", "value": "</sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\", </llms.txt>; rel=\"llms-txt\"; type=\"text/markdown\", </.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </.well-known/agent-skills/index.json>; rel=\"agent-skills\"; type=\"application/json\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"oauth-protected-resource\"; type=\"application/json\", </.well-known/oauth-authorization-server>; rel=\"oauth-authorization-server\"; type=\"application/json\", </.well-known/openid-configuration>; rel=\"openid-configuration\"; type=\"application/json\"" }
+        { "key": "Link", "value": "</sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\", </llms.txt>; rel=\"llms-txt\"; type=\"text/markdown\", </.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </.well-known/mcp.json>; rel=\"mcp\"; type=\"application/json\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; type=\"application/json\", </.well-known/agent-skills/index.json>; rel=\"agent-skills\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"oauth-protected-resource\"; type=\"application/json\", </.well-known/oauth-authorization-server>; rel=\"oauth-authorization-server\"; type=\"application/json\", </.well-known/openid-configuration>; rel=\"openid-configuration\"; type=\"application/json\"" }
       ]
     },
     {
@@ -134,6 +142,24 @@
     },
     {
       "source": "/.well-known/mcp/server-card.json",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json; charset=utf-8" }
+      ]
+    },
+    {
+      "source": "/.well-known/mcp.json",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json; charset=utf-8" }
+      ]
+    },
+    {
+      "source": "/.well-known/mcp",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json; charset=utf-8" }
+      ]
+    },
+    {
+      "source": "/mcp",
       "headers": [
         { "key": "Content-Type", "value": "application/json; charset=utf-8" }
       ]


### PR DESCRIPTION
## Summary

Upgrades DeFi Garden's AI search (AEO/GEO) and autonomous agent readiness to Level 5, ensuring full discoverability and in-browser / HTTP tool execution for autonomous wallets and search crawlers.

### Key Changes
1. **Robots & AI Content Signals:**
   - Added Cloudflare standard `Content-signal: search=yes, ai-train=no, use=reference`.
   - Explicitly allowed `ClaudeBot`, `Claude-Web`, `GPTBot`, `ChatGPT-User`, `PerplexityBot`, `Applebot-Extended`, `Google-Extended`, `OAI-SearchBot`, and `Amazonbot`.

2. **`llms.txt` Generator Hardening (`generate-llms.js`, `llms.txt`, `llms-full.txt`):**
   - Embedded the Garden Planner section (archetypes, 'Forever Number' formula, live blended rate).
   - Embedded the Model Context Protocol (MCP) streamable HTTP endpoints (`https://www.defi.garden/mcp`) and tool specifications (`find_pools`, `get_pool`, `forever_number`, `explain_rails`).

3. **WebMCP In-Browser Agent Support (`home.html`, `plan.html`):**
   - Injected `window.navigator.modelContext.provideContext({ tools: [...] })` into both root surfaces for browser-native agent execution of `find_pools` and `forever_number`.

4. **Schema.org Structured Data (`home.html`, `plan.html`):**
   - Added `WebApplication` / `FinancialService` and `BreadcrumbList` JSON-LD schemas explicitly documenting MCP tools and deterministic trust rails.

5. **OpenAPI & MCP Discovery Manifests (`openapi.json`, `.well-known/mcp.json`, `vercel.json`):**
   - Expanded `openapi.json` with endpoints for `/pools`, `/pools/{id}`, `/planner`, `/forever-number`, `/pricing`, and `/health`.
   - Updated `.well-known/mcp.json` and `server-card.json` declaring `streamable-http` and `sse` transports.
   - Configured Vercel rewrites and `Link` response headers for MCP discovery.

### Verification
- `node validate-sitemaps.js` — PASS (111/111 sitemaps valid)
- `node test_og_images.js` — PASS (18/18 assertions)
- `node test_spotlight.js` — PASS (38/38 assertions)